### PR TITLE
File-scoped namespaces

### DIFF
--- a/MNES.Core/Machine/Apu.cs
+++ b/MNES.Core/Machine/Apu.cs
@@ -4,16 +4,15 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Mnes.Core.Machine
-{
-    public class Apu
-    {
-        /// <summary> Also contains some IO registers. </summary>
-        public byte[] Registers = new byte[32];
+namespace Mnes.Core.Machine;
 
-        public void SetPowerUpState()
-        {
-            Array.Clear(Registers);
-        }
+public class Apu
+{
+    /// <summary> Also contains some IO registers. </summary>
+    public byte[] Registers = new byte[32];
+
+    public void SetPowerUpState()
+    {
+        Array.Clear(Registers);
     }
 }

--- a/MNES.Core/Machine/CPU/Cpu.cs
+++ b/MNES.Core/Machine/CPU/Cpu.cs
@@ -8,1108 +8,1107 @@ using System.Threading.Tasks;
 using static Mnes.Core.Machine.CPU.CpuInstruction;
 using static Mnes.Core.Machine.CpuRegisters;
 
-namespace Mnes.Core.Machine.CPU
+namespace Mnes.Core.Machine.CPU;
+
+// https://www.masswerk.at/6502/6502_instruction_set.html
+public class Cpu
 {
-    // https://www.masswerk.at/6502/6502_instruction_set.html
-    public class Cpu
+    public readonly CpuRegisters Registers = new();
+    readonly MachineState machine;
+    readonly CpuInstruction[] instructions = new CpuInstruction[256];
+
+    CpuInstruction CurrentInstruction;
+    int CurrentInstructionCycle;
+    long CycleCounter = 6;
+
+    // temp values used to store data across clock cycles within a single instruction
+    ushort tmp_u;
+
+    // Add additional cycles after an instruction
+    int add_cycles;
+
+    // values that are recorded during logging
+    ushort log_pc;
+    byte? log_d1;
+    byte? log_d2;
+    long log_cyc;
+    string log_message;
+    CpuRegisterLog log_cpu;
+    long log_inst_count;
+
+    #region Utility Functions
+    /// <summary> Set PC lower byte. </summary>
+    static void PCL(MachineState m, byte value) {
+        m.Cpu.Registers.PC &= 0b_1111_1111_0000_0000;
+        m.Cpu.Registers.PC |= value;
+    }
+
+    /// <summary> Set PC higher byte. </summary>
+    static void PCH(MachineState m, byte value) {
+        m.Cpu.Registers.PC &= 0b_0000_0000_1111_1111;
+        m.Cpu.Registers.PC |= (ushort)(value << 8);
+    }
+
+    static void PUSH(MachineState m, byte value)
     {
-        public readonly CpuRegisters Registers = new();
-        readonly MachineState machine;
-        readonly CpuInstruction[] instructions = new CpuInstruction[256];
+        m[(ushort)(m.Cpu.Registers.S-- + 0x0100)] = value;
+    }
 
-        CpuInstruction CurrentInstruction;
-        int CurrentInstructionCycle;
-        long CycleCounter = 6;
+    static void PUSH_ushort(MachineState m, ushort value)
+    {
+        PUSH(m, (byte)(value >> 8));
+        PUSH(m, (byte)value);
+    }
 
-        // temp values used to store data across clock cycles within a single instruction
-        ushort tmp_u;
+    static ushort PULL_ushort(MachineState m)
+    {
+        ushort value = PULL(m);
+        value |= (ushort)((ushort)PULL(m) << 8);
+        return value;
+    }
 
-        // Add additional cycles after an instruction
-        int add_cycles;
+    static byte PULL(MachineState m) =>
+        m[(ushort)(++m.Cpu.Registers.S + 0x0100)];
 
-        // values that are recorded during logging
-        ushort log_pc;
-        byte? log_d1;
-        byte? log_d2;
-        long log_cyc;
-        string log_message;
-        CpuRegisterLog log_cpu;
-        long log_inst_count;
+    static ushort GetIndexedZeroPageIndirectAddress(MachineState m, byte arg, byte r)
+    {
+        // X-Indexed Zero Page Indirect https://www.pagetable.com/c64ref/6502/?tab=3#(a8,X)
+        var x_target = (byte)(arg + r);
 
-        #region Utility Functions
-        /// <summary> Set PC lower byte. </summary>
-        static void PCL(MachineState m, byte value) {
-            m.Cpu.Registers.PC &= 0b_1111_1111_0000_0000;
-            m.Cpu.Registers.PC |= value;
-        }
+        // "var target = m.ReadUShort(x_target);", except both indexes must be in zero page
+        var b_l = m[x_target];
+        ushort b_h = m[(ushort)((x_target + 1) % 256)];
+        b_h <<= 8;
+        b_h |= b_l;
+        var target = b_h;
 
-        /// <summary> Set PC higher byte. </summary>
-        static void PCH(MachineState m, byte value) {
-            m.Cpu.Registers.PC &= 0b_0000_0000_1111_1111;
-            m.Cpu.Registers.PC |= (ushort)(value << 8);
-        }
+        if (m.Settings.System.DebugMode) m.Cpu.log_message =
+            $"(${arg:X2},X) = @ {x_target:X2} = {target:X4} = {m[target]:X2}";
 
-        static void PUSH(MachineState m, byte value)
+        return target;
+    }
+
+    #endregion
+
+    // Some opcodes do similar things
+    #region Generic Opcode Methods
+    static void OpSetFlag(MachineState m, StatusFlagType flag)
+    {
+        m.Cpu.Registers.P |= (byte)flag;
+        m.Cpu.Registers.PC++;
+    }
+
+    static void OpClearFlag(MachineState m, StatusFlagType flag)
+    {
+        m.Cpu.Registers.ClearFlag(flag);
+        m.Cpu.Registers.PC++;
+    }
+
+    static void OpBranchOnFlagRelative(MachineState m, StatusFlagType flag)
+    {
+        if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${m.Cpu.Registers.PC + m[(ushort)(m.Cpu.Registers.PC + 1)] + 2:X4}";
+
+        if (m.Cpu.Registers.HasFlag(flag))
         {
-            m[(ushort)(m.Cpu.Registers.S-- + 0x0100)] = value;
+            m.Cpu.Registers.PC += m[(ushort)(m.Cpu.Registers.PC + 1)];
         }
 
-        static void PUSH_ushort(MachineState m, ushort value)
+        m.Cpu.add_cycles = 1; // Todo: Add another if branch is on another page
+        m.Cpu.Registers.PC += 2;
+    }
+
+    static void OpBranchOnClearFlagRelative(MachineState m, StatusFlagType flag)
+    {
+        if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${m.Cpu.Registers.PC + m[(ushort)(m.Cpu.Registers.PC + 1)] + 2:X4}";
+
+        if (!m.Cpu.Registers.HasFlag(flag))
         {
-            PUSH(m, (byte)(value >> 8));
-            PUSH(m, (byte)value);
+            m.Cpu.Registers.PC += m[(ushort)(m.Cpu.Registers.PC + 1)];
         }
+        m.Cpu.add_cycles = 1; // Todo: Add another if branch is on another page
+        m.Cpu.Registers.PC += 2;
+    }
 
-        static ushort PULL_ushort(MachineState m)
-        {
-            ushort value = PULL(m);
-            value |= (ushort)((ushort)PULL(m) << 8);
-            return value;
+    static void OpCompare(MachineState m, byte r, byte mem)
+    {
+        m.Cpu.Registers.SetFlag(StatusFlagType.Negative, ((r - mem) & 0b_1000_0000) > 0);
+        m.Cpu.Registers.SetFlag(StatusFlagType.Zero, r == mem);
+        m.Cpu.Registers.SetFlag(StatusFlagType.Carry, mem <= r);
+    }
+
+    static void OpAddCarry(MachineState m, byte value)
+    {
+        var a = m.Cpu.Registers.A;
+        var sum = a + value + (m.Cpu.Registers.HasFlag(StatusFlagType.Carry)? 1 : 0);
+        var carry = sum > 0xFF;
+        var overflow = (~(a ^ value) & (a ^ sum) & 0x80) > 0;
+        m.Cpu.Registers.A = (byte)sum;
+        m.Cpu.Registers.SetFlag(StatusFlagType.Carry, carry);
+        m.Cpu.Registers.SetFlag(StatusFlagType.Overflow, overflow);
+    }
+
+    static void OpRollingLeftShiftMem(MachineState m, ushort target)
+    {
+        var prev_carry = m.Cpu.Registers.HasFlag(StatusFlagType.Carry);
+        var c_flag = (m[target] & 0b_1000_0000) > 0;
+        m[target] <<= 1;
+        if (prev_carry) m[target] |= 0b_0000_0001;
+        m.Cpu.Registers.UpdateFlags(m[target]);
+        m.Cpu.Registers.SetFlag(StatusFlagType.Carry, c_flag);
+    }
+
+    static void OpRollingRightShiftMem(MachineState m, ushort target)
+    {
+        var prev_carry = m.Cpu.Registers.HasFlag(StatusFlagType.Carry);
+        var c_flag = (m[target] & 0b_0000_0001) > 0;
+        m[target] >>= 1;
+        if (prev_carry) m[target] |= 0b_1000_0000;
+        m.Cpu.Registers.UpdateFlags(m[target]);
+        m.Cpu.Registers.SetFlag(StatusFlagType.Carry, c_flag);
+    }
+    // Todo; make sure all address setting functions are setting flags properly
+    static void OpIncMem(MachineState m, ushort target)
+    {
+        m[target]++;
+        m.Cpu.Registers.UpdateFlags(m[target]);
+    }
+
+    static void OpDecMem(MachineState m, ushort target)
+    {
+        m[target]--;
+        m.Cpu.Registers.UpdateFlags(m[target]);
+    }
+
+    static void OpBit(MachineState m, byte value)
+    {
+        m.Cpu.Registers.SetFlag(StatusFlagType.Zero, (m.Cpu.Registers.A & value) == 0);
+        m.Cpu.Registers.SetFlag(StatusFlagType.Negative, (value & 0b_1000_0000) > 0);
+        m.Cpu.Registers.SetFlag(StatusFlagType.Overflow, (value & 0b_0100_0000) > 0);
+    }
+    #endregion
+
+    static readonly CpuInstruction[] instructions_unordered = new CpuInstruction[] {
+
+        new() { Name = "JMP", OpCode = 0x4C, Bytes = 3, Process = new ProcessDelegate[] {
+            m => {
+                m.Cpu.tmp_u = m.Cpu.Registers.PC;
+                PCL(m, m[(ushort)(m.Cpu.tmp_u + 1)]);
+            },
+            m => {
+                PCH(m, m[(ushort)(m.Cpu.tmp_u + 2)]);
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${m.Cpu.Registers.PC:X4}";
+            },
+        } },
+
+        new() { Name = "LDX", OpCode = 0xA2, Bytes = 2, Process = new ProcessDelegate[] {
+            m => {
+                m.Cpu.Registers.X = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                m.Cpu.Registers.PC += 2;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"#${m.Cpu.Registers.X:X2}";
+            },
+        } },
+
+        new() { Name = "STX", OpCode = 0x86, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
+                m[target] = m.Cpu.Registers.X;
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "JSR", OpCode = 0x20, Bytes = 3, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => {
+                PUSH_ushort(m, (ushort)(m.Cpu.Registers.PC + 2));
+                m.Cpu.Registers.PC = m.ReadUShort(m.Cpu.Registers.PC + 1);
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${m.Cpu.Registers.PC:X4}";
+            },
+        } },
+
+        new() { Name = "RTS", OpCode = 0x60, Bytes = 1, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => {
+                ushort target = PULL(m);
+                target |= (ushort)((ushort)PULL(m) << 8);
+                m.Cpu.Registers.PC = target;
+                m.Cpu.Registers.PC += 1;
+            },
+        } },
+
+        new() { Name = "NOP", OpCode = 0xEA, Bytes = 1, Process = new ProcessDelegate[] {
+            m => { m.Cpu.Registers.PC++; },
+        } },
+
+        new() { Name = "SEC", OpCode = 0x38, Bytes = 1, Process = new ProcessDelegate[] {
+            m => OpSetFlag(m, StatusFlagType.Carry),
+        } },
+
+        new() { Name = "BCS", OpCode = 0xB0, Bytes = 2, Process = new ProcessDelegate[] {
+            m => OpBranchOnFlagRelative(m, StatusFlagType.Carry),
+        } },
+
+        new() { Name = "CLC", OpCode = 0x18, Bytes = 1, Process = new ProcessDelegate[] {
+            m => OpClearFlag(m, StatusFlagType.Carry),
+        } },
+
+        new() { Name = "BCC", OpCode = 0x90, Bytes = 2, Process = new ProcessDelegate[] {
+            m => OpBranchOnClearFlagRelative(m, StatusFlagType.Carry),
+        } },
+
+        new() { Name = "LDA", OpCode = 0xA9, Bytes = 2, Process = new ProcessDelegate[] {
+            m => {
+                m.Cpu.Registers.A = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                m.Cpu.Registers.PC += 2;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"#${m.Cpu.Registers.A:X2}";
+            },
+        } },
+
+        new() { Name = "BEQ", OpCode = 0xF0, Bytes = 2, Process = new ProcessDelegate[] {
+            m => OpBranchOnFlagRelative(m, StatusFlagType.Zero),
+        } },
+
+        new() { Name = "BNE", OpCode = 0xD0, Bytes = 2, Process = new ProcessDelegate[] {
+            m => OpBranchOnClearFlagRelative(m, StatusFlagType.Zero),
+        } },
+
+        new() { Name = "STA", OpCode = 0x85, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
+                m[target] = m.Cpu.Registers.A;
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "BIT", OpCode = 0x24, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var z_p_address = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                var value = m[z_p_address];
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${z_p_address:X2} = {value:X2}";
+                OpBit(m, value);
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "BVS", OpCode = 0x70, Bytes = 2, Process = new ProcessDelegate[] {
+            m => OpBranchOnFlagRelative(m, StatusFlagType.Overflow),
+        } },
+
+        new() { Name = "BVC", OpCode = 0x50, Bytes = 2, Process = new ProcessDelegate[] {
+            m => OpBranchOnClearFlagRelative(m, StatusFlagType.Overflow),
+        } },
+
+        new() { Name = "BPL", OpCode = 0x10, Bytes = 2, Process = new ProcessDelegate[] {
+            m => OpBranchOnClearFlagRelative(m, StatusFlagType.Negative),
+        } },
+
+        new() { Name = "SEI", OpCode = 0x78, Bytes = 1, Process = new ProcessDelegate[] {
+            m => OpSetFlag(m, StatusFlagType.InerruptDisable),
+        } },
+
+        new() { Name = "SED", OpCode = 0xF8, Bytes = 1, Process = new ProcessDelegate[] {
+            m => OpSetFlag(m, StatusFlagType.Decimal),
+        } },
+
+        new() { Name = "PHP", OpCode = 0x08, Bytes = 1, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var p = m.Cpu.Registers.P;
+                p |= 0b_0010_0000;
+                PUSH(m, p);
+                m.Cpu.Registers.PC++;
+            },
+        } },
+
+        new() { Name = "PLA", OpCode = 0x68, Bytes = 1, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => {
+                m.Cpu.Registers.A = PULL(m);
+                m.Cpu.Registers.PC++;
+            },
+        } },
+
+        new() { Name = "AND", OpCode = 0x29, Bytes = 2, Process = new ProcessDelegate[] {
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                m.Cpu.Registers.A &= target;
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "CMP", OpCode = 0xC9, Bytes = 2, Process = new ProcessDelegate[] {
+            m => {
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"#${m[(ushort)(m.Cpu.Registers.PC + 1)]:X2}";
+                OpCompare(m, m.Cpu.Registers.A, m[(ushort)(m.Cpu.Registers.PC + 1)]);
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "CLD", OpCode = 0xD8, Bytes = 1, Process = new ProcessDelegate[] {
+            m => OpClearFlag(m, StatusFlagType.Decimal),
+        } },
+
+        new() { Name = "PHA", OpCode = 0x48, Bytes = 1, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                PUSH(m, m.Cpu.Registers.A);
+                m.Cpu.Registers.PC++;
+            },
+        } },
+
+        new() { Name = "PLP", OpCode = 0x28, Bytes = 1, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => {
+                var b_flag = m.Cpu.Registers.HasFlag(StatusFlagType.BFlag);
+                m.Cpu.Registers.P = PULL(m);
+                m.Cpu.Registers.SetFlag(StatusFlagType.BFlag, b_flag);
+                m.Cpu.Registers.PC++;
+            },
+        } },
+
+        new() { Name = "BMI", OpCode = 0x30, Bytes = 2, Process = new ProcessDelegate[] {
+            m => OpBranchOnFlagRelative(m, StatusFlagType.Negative),
+        } },
+
+        new() { Name = "ORA", OpCode = 0x09, Bytes = 2, Process = new ProcessDelegate[] {
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                m.Cpu.Registers.A |= target;
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "CLV", OpCode = 0xB8, Bytes = 1, Process = new ProcessDelegate[] {
+            m => OpClearFlag(m, StatusFlagType.Overflow),
+        } },
+
+        new() { Name = "EOR", OpCode = 0x49, Bytes = 2, Process = new ProcessDelegate[] {
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                m.Cpu.Registers.A ^= target;
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "ADC", OpCode = 0x69, Bytes = 2, Process = new ProcessDelegate[] {
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"#${target:X2}";
+                OpAddCarry(m, target);
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "LDY", OpCode = 0xA0, Bytes = 2, Process = new ProcessDelegate[] {
+            m => {
+                m.Cpu.Registers.Y = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                m.Cpu.Registers.PC += 2;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"#${m.Cpu.Registers.Y:X2}";
+            },
+        } },
+
+        new() { Name = "CPY", OpCode = 0xC0, Bytes = 2, Process = new ProcessDelegate[] {
+            m => {
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"#${m[(ushort)(m.Cpu.Registers.PC + 1)]:X2}";
+                OpCompare(m, m.Cpu.Registers.Y, m[(ushort)(m.Cpu.Registers.PC + 1)]);
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "CPX", OpCode = 0xE0, Bytes = 2, Process = new ProcessDelegate[] {
+            m => {
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"#${m[(ushort)(m.Cpu.Registers.PC + 1)]:X2}";
+                OpCompare(m, m.Cpu.Registers.X, m[(ushort)(m.Cpu.Registers.PC + 1)]);
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "SBC", OpCode = 0xE9, Bytes = 2, Process = new ProcessDelegate[] {
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"#${target:X2}";
+                OpAddCarry(m, (byte)~target);
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "INY", OpCode = 0xC8, Bytes = 1, Process = new ProcessDelegate[] {
+            m => {
+                m.Cpu.Registers.Y++;
+                m.Cpu.Registers.PC += 1;
+            },
+        } },
+
+        new() { Name = "INX", OpCode = 0xE8, Bytes = 1, Process = new ProcessDelegate[] {
+            m => {
+                m.Cpu.Registers.X++;
+                m.Cpu.Registers.PC += 1;
+            },
+        } },
+
+        new() { Name = "DEY", OpCode = 0x88, Bytes = 1, Process = new ProcessDelegate[] {
+            m => {
+                m.Cpu.Registers.Y--;
+                m.Cpu.Registers.PC += 1;
+            },
+        } },
+
+        new() { Name = "DEX", OpCode = 0xCA, Bytes = 1, Process = new ProcessDelegate[] {
+            m => {
+                m.Cpu.Registers.X--;
+                m.Cpu.Registers.PC += 1;
+            },
+        } },
+
+        new() { Name = "TAY", OpCode = 0xA8, Bytes = 1, Process = new ProcessDelegate[] {
+            m => {
+                m.Cpu.Registers.Y = m.Cpu.Registers.A;
+                m.Cpu.Registers.PC += 1;
+            },
+        } },
+
+        new() { Name = "TAX", OpCode = 0xAA, Bytes = 1, Process = new ProcessDelegate[] {
+            m => {
+                m.Cpu.Registers.X = m.Cpu.Registers.A;
+                m.Cpu.Registers.PC += 1;
+            },
+        } },
+
+        new() { Name = "TYA", OpCode = 0x98, Bytes = 1, Process = new ProcessDelegate[] {
+            m => {
+                m.Cpu.Registers.A = m.Cpu.Registers.Y;
+                m.Cpu.Registers.PC += 1;
+            },
+        } },
+
+        new() { Name = "TXA", OpCode = 0x8A, Bytes = 1, Process = new ProcessDelegate[] {
+            m => {
+                m.Cpu.Registers.A = m.Cpu.Registers.X;
+                m.Cpu.Registers.PC += 1;
+            },
+        } },
+
+        new() { Name = "TSX", OpCode = 0xBA, Bytes = 1, Process = new ProcessDelegate[] {
+            m => {
+                m.Cpu.Registers.X = m.Cpu.Registers.S;
+                m.Cpu.Registers.PC += 1;
+            },
+        } },
+
+
+        new() { Name = "STX", OpCode = 0x8E, Bytes = 3, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => {
+                var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
+                m[target] = m.Cpu.Registers.X;
+                m.Cpu.Registers.PC += 3;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m.Cpu.Registers.X:X2}";
+            },
+        } },
+
+        new() { Name = "TXS", OpCode = 0x9A, Bytes = 1, Process = new ProcessDelegate[] {
+            m => {
+                m.Cpu.Registers.S = m.Cpu.Registers.X;
+                m.Cpu.Registers.PC += 1;
+            },
+        } },
+
+        new() { Name = "LDX", OpCode = 0xAE, Bytes = 3, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => {
+                var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
+                m.Cpu.Registers.X = m[target];
+                m.Cpu.Registers.PC += 3;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m.Cpu.Registers.X:X2}";
+            },
+        } },
+
+        new() { Name = "LDA", OpCode = 0xAD, Bytes = 3, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => {
+                var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
+                m.Cpu.Registers.A = m[target];
+                m.Cpu.Registers.PC += 3;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m.Cpu.Registers.A:X2}";
+            },
+        } },
+
+        new() { Name = "DEC", OpCode = 0xCE, Bytes = 3, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => {
+                var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
+                m[target]--;
+                m.Cpu.Registers.PC += 3;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m.Cpu.Registers.A:X2}";
+            },
+        } },
+
+        new() { Name = "RTI", OpCode = 0x40, Bytes = 1, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => {
+                m.Cpu.Registers.P = PULL(m);
+                m.Cpu.Registers.PC = PULL_ushort(m);
+            },
+        } },
+
+        new() { Name = "LSR", OpCode = 0x4A, Bytes = 1, Process = new ProcessDelegate[] {
+            m => {
+                var c_flag = (m.Cpu.Registers.A & 0b_0000_0001) > 0;
+                m.Cpu.Registers.A >>= 1;
+                m.Cpu.Registers.SetFlag(StatusFlagType.Carry, c_flag);
+                m.Cpu.Registers.PC += 1;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"A";
+            },
+        } },
+
+        new() { Name = "ASL", OpCode = 0x0A, Bytes = 1, Process = new ProcessDelegate[] {
+            m => {
+                var c_flag = (m.Cpu.Registers.A & 0b_1000_0000) > 0;
+                m.Cpu.Registers.A <<= 1;
+                m.Cpu.Registers.SetFlag(StatusFlagType.Carry, c_flag);
+                m.Cpu.Registers.PC += 1;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"A";
+            },
+        } },
+
+        new() { Name = "ROR", OpCode = 0x6A, Bytes = 1, Process = new ProcessDelegate[] {
+            m => {
+                var prev_carry = m.Cpu.Registers.HasFlag(StatusFlagType.Carry);
+                var c_flag = (m.Cpu.Registers.A & 0b_0000_0001) > 0;
+                m.Cpu.Registers.A >>= 1;
+                if (prev_carry) m.Cpu.Registers.A |= 0b_1000_0000;
+                m.Cpu.Registers.SetFlag(StatusFlagType.Carry, c_flag);
+                m.Cpu.Registers.PC += 1;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"A";
+            },
+        } },
+
+        new() { Name = "ROL", OpCode = 0x2A, Bytes = 1, Process = new ProcessDelegate[] {
+            m => {
+                var prev_carry = m.Cpu.Registers.HasFlag(StatusFlagType.Carry);
+                var c_flag = (m.Cpu.Registers.A & 0b_1000_0000) > 0;
+                m.Cpu.Registers.A <<= 1;
+                if (prev_carry) m.Cpu.Registers.A |= 0b_0000_0001;
+                m.Cpu.Registers.SetFlag(StatusFlagType.Carry, c_flag);
+                m.Cpu.Registers.PC += 1;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"A";
+            },
+        } },
+
+        new() { Name = "LDA", OpCode = 0xA5, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                m.Cpu.Registers.A = m[target];
+                m.Cpu.Registers.PC += 2;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m.Cpu.Registers.A:X2}";
+            },
+        } },
+
+        new() { Name = "STA", OpCode = 0x8D, Bytes = 3, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => { },
+            m => {
+                var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m[target]:X2}";
+                m[target] = m.Cpu.Registers.A;
+                m.Cpu.Registers.PC += 3;
+            },
+        } },
+
+        new() { Name = "LDA", OpCode = 0xA1, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => {
+                var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                var target = GetIndexedZeroPageIndirectAddress(m, arg, m.Cpu.Registers.X);
+                m.Cpu.Registers.A = m[target];
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "STA", OpCode = 0x81, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => {
+                var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                var target = GetIndexedZeroPageIndirectAddress(m, arg, m.Cpu.Registers.X);
+                m[target] = m.Cpu.Registers.A;
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "ORA", OpCode = 0x01, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => {
+                var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                var target = GetIndexedZeroPageIndirectAddress(m, arg, m.Cpu.Registers.X);
+                m.Cpu.Registers.A |= m[target];
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "AND", OpCode = 0x21, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => {
+                var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                var target = GetIndexedZeroPageIndirectAddress(m, arg, m.Cpu.Registers.X);
+                m.Cpu.Registers.A &= m[target];
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "EOR", OpCode = 0x41, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => {
+                var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                var target = GetIndexedZeroPageIndirectAddress(m, arg, m.Cpu.Registers.X);
+                m.Cpu.Registers.A ^= m[target];
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "ADC", OpCode = 0x61, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => {
+                var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                var target = GetIndexedZeroPageIndirectAddress(m, arg, m.Cpu.Registers.X);
+                OpAddCarry(m, m[target]);
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "CMP", OpCode = 0xC1, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => {
+                var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                var target = GetIndexedZeroPageIndirectAddress(m, arg, m.Cpu.Registers.X);
+                OpCompare(m, m.Cpu.Registers.A, m[target]);
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "SBC", OpCode = 0xE1, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => {
+                var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                var target = GetIndexedZeroPageIndirectAddress(m, arg, m.Cpu.Registers.X);
+                OpAddCarry(m, (byte)~m[target]);
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "LDY", OpCode = 0xA4, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                m.Cpu.Registers.Y = m[target];
+                m.Cpu.Registers.PC += 2;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m.Cpu.Registers.Y:X2}";
+            },
+        } },
+
+        new() { Name = "STY", OpCode = 0x84, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                m[target] = m.Cpu.Registers.Y;
+                m.Cpu.Registers.PC += 2;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m.Cpu.Registers.Y:X2}";
+            },
+        } },
+
+        new() { Name = "LDX", OpCode = 0xA6, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                m.Cpu.Registers.X = m[target];
+                m.Cpu.Registers.PC += 2;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m.Cpu.Registers.X:X2}";
+            },
+        } },
+
+        new() { Name = "ORA", OpCode = 0x05, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                m.Cpu.Registers.A |= m[target];
+                m.Cpu.Registers.PC += 2;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
+            },
+        } },
+
+        new() { Name = "AND", OpCode = 0x25, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                m.Cpu.Registers.A &= m[target];
+                m.Cpu.Registers.PC += 2;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
+            },
+        } },
+
+        new() { Name = "EOR", OpCode = 0x45, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                m.Cpu.Registers.A ^= m[target];
+                m.Cpu.Registers.PC += 2;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
+            },
+        } },
+
+        new() { Name = "ADC", OpCode = 0x65, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                OpAddCarry(m, (byte)m[target]);
+                m.Cpu.Registers.PC += 2;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
+            },
+        } },
+
+        new() { Name = "CMP", OpCode = 0xC5, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                OpCompare(m, m.Cpu.Registers.A, m[target]);
+                m.Cpu.Registers.PC += 2;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
+            },
+        } },
+
+        new() { Name = "SBC", OpCode = 0xE5, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
+                OpAddCarry(m, (byte)~m[target]);
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "CPX", OpCode = 0xE4, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                OpCompare(m, m.Cpu.Registers.X, m[target]);
+                m.Cpu.Registers.PC += 2;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
+            },
+        } },
+
+        new() { Name = "CPY", OpCode = 0xC4, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                OpCompare(m, m.Cpu.Registers.Y, m[target]);
+                m.Cpu.Registers.PC += 2;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
+            },
+        } },
+
+        new() { Name = "LSR", OpCode = 0x46, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${arg:X2} = {m[arg]:X2}";
+
+                var c_flag = (m[arg] & 0b_0000_0001) > 0;
+                m[arg] >>= 1;
+                m.Cpu.Registers.SetFlag(StatusFlagType.Carry, c_flag);
+
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "ASL", OpCode = 0x06, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => {
+                var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${arg:X2} = {m[arg]:X2}";
+
+                var c_flag = (m[arg] & 0b_1000_0000) > 0;
+                m[arg] <<= 1;
+                m.Cpu.Registers.SetFlag(StatusFlagType.Carry, c_flag);
+
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "ROR", OpCode = 0x66, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => {
+                var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${arg:X2} = {m[arg]:X2}";
+
+                OpRollingRightShiftMem(m, arg);
+
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "ROL", OpCode = 0x26, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => {
+                var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${arg:X2} = {m[arg]:X2}";
+
+                OpRollingLeftShiftMem(m, arg);
+
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "INC", OpCode = 0xE6, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => {
+                var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${arg:X2} = {m[arg]:X2}";
+
+                OpIncMem(m, arg);
+
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "DEC", OpCode = 0xC6, Bytes = 2, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => { },
+            m => { },
+            m => {
+                var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${arg:X2} = {m[arg]:X2}";
+
+                OpDecMem(m, arg);
+
+                m.Cpu.Registers.PC += 2;
+            },
+        } },
+
+        new() { Name = "LDY", OpCode = 0xAC, Bytes = 3, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => {
+                var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
+                m.Cpu.Registers.Y = m[target];
+                m.Cpu.Registers.PC += 3;
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m.Cpu.Registers.Y:X2}";
+            },
+        } },
+
+        new() { Name = "STY", OpCode = 0x8C, Bytes = 3, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => {
+                var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m[target]:X2}";
+                m[target] = m.Cpu.Registers.Y;
+                m.Cpu.Registers.PC += 3;
+            },
+        } },
+
+        new() { Name = "BIT", OpCode = 0x2C, Bytes = 3, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => {
+                var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m[target]:X2}";
+                OpBit(m, m[target]);
+                m.Cpu.Registers.PC += 3;
+            },
+        } },
+
+        new() { Name = "ORA", OpCode = 0x0D, Bytes = 3, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => {
+                var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m[target]:X2}";
+                m.Cpu.Registers.A |= m[target];
+                m.Cpu.Registers.PC += 3;
+            },
+        } },
+
+        new() { Name = "AND", OpCode = 0x2D, Bytes = 3, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => {
+                var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m[target]:X2}";
+                m.Cpu.Registers.A &= m[target];
+                m.Cpu.Registers.PC += 3;
+            },
+        } },
+
+        new() { Name = "EOR", OpCode = 0x4D, Bytes = 3, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => {
+                var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m[target]:X2}";
+                m.Cpu.Registers.A ^= m[target];
+                m.Cpu.Registers.PC += 3;
+            },
+        } },
+
+        new() { Name = "ADC", OpCode = 0x6D, Bytes = 3, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => {
+                var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m[target]:X2}";
+                OpAddCarry(m, m[target]);
+                m.Cpu.Registers.PC += 3;
+            },
+        } },
+
+        new() { Name = "CMP", OpCode = 0xCD, Bytes = 3, Process = new ProcessDelegate[] {
+            m => { },
+            m => { },
+            m => {
+                var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
+                if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m[target]:X2}";
+                OpCompare(m, m.Cpu.Registers.A, m[target]);
+                m.Cpu.Registers.PC += 3;
+            },
+        } },
+    };
+
+    public Cpu(MachineState machine)
+    {
+        this.machine = machine;
+        foreach (var i in instructions_unordered) {
+            if (instructions[i.OpCode] != null) throw new Exception($"Duplicate OpCodes: {instructions[i.OpCode].Name} and {i.Name}");
+            instructions[i.OpCode] = i;
         }
+    }
 
-        static byte PULL(MachineState m) =>
-            m[(ushort)(++m.Cpu.Registers.S + 0x0100)];
+    public void SetPowerUpState()
+    {
+        Registers.PC = 0x34;
+        Registers.X = 0;
+        Registers.Y = 0;
+        Registers.A = 0;
 
-        static ushort GetIndexedZeroPageIndirectAddress(MachineState m, byte arg, byte r)
+        // I just put InerruptDisable/0xFD here because these seem to be set in the nestest.log file by the time it gets here but I haven't found anything in documentation to say why
+        Registers.P = (byte)StatusFlagType._1 | (byte)StatusFlagType.InerruptDisable;
+        Registers.S = 0xFD;
+    }
+
+    public void Tick()
+    {
+        CycleCounter++;
+        if (CurrentInstruction == null)
         {
-            // X-Indexed Zero Page Indirect https://www.pagetable.com/c64ref/6502/?tab=3#(a8,X)
-            var x_target = (byte)(arg + r);
-
-            // "var target = m.ReadUShort(x_target);", except both indexes must be in zero page
-            var b_l = m[x_target];
-            ushort b_h = m[(ushort)((x_target + 1) % 256)];
-            b_h <<= 8;
-            b_h |= b_l;
-            var target = b_h;
-
-            if (m.Settings.System.DebugMode) m.Cpu.log_message =
-                $"(${arg:X2},X) = @ {x_target:X2} = {target:X4} = {m[target]:X2}";
-
-            return target;
-        }
-
-        #endregion
-
-        // Some opcodes do similar things
-        #region Generic Opcode Methods
-        static void OpSetFlag(MachineState m, StatusFlagType flag)
-        {
-            m.Cpu.Registers.P |= (byte)flag;
-            m.Cpu.Registers.PC++;
-        }
-
-        static void OpClearFlag(MachineState m, StatusFlagType flag)
-        {
-            m.Cpu.Registers.ClearFlag(flag);
-            m.Cpu.Registers.PC++;
-        }
-
-        static void OpBranchOnFlagRelative(MachineState m, StatusFlagType flag)
-        {
-            if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${m.Cpu.Registers.PC + m[(ushort)(m.Cpu.Registers.PC + 1)] + 2:X4}";
-            
-            if (m.Cpu.Registers.HasFlag(flag))
-            {
-                m.Cpu.Registers.PC += m[(ushort)(m.Cpu.Registers.PC + 1)];
-            }
-
-            m.Cpu.add_cycles = 1; // Todo: Add another if branch is on another page
-            m.Cpu.Registers.PC += 2;
-        }
-
-        static void OpBranchOnClearFlagRelative(MachineState m, StatusFlagType flag)
-        {
-            if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${m.Cpu.Registers.PC + m[(ushort)(m.Cpu.Registers.PC + 1)] + 2:X4}";
-
-            if (!m.Cpu.Registers.HasFlag(flag))
-            {
-                m.Cpu.Registers.PC += m[(ushort)(m.Cpu.Registers.PC + 1)];
-            }
-            m.Cpu.add_cycles = 1; // Todo: Add another if branch is on another page
-            m.Cpu.Registers.PC += 2;
-        }
-
-        static void OpCompare(MachineState m, byte r, byte mem)
-        {
-            m.Cpu.Registers.SetFlag(StatusFlagType.Negative, ((r - mem) & 0b_1000_0000) > 0);
-            m.Cpu.Registers.SetFlag(StatusFlagType.Zero, r == mem);
-            m.Cpu.Registers.SetFlag(StatusFlagType.Carry, mem <= r);
-        }
-
-        static void OpAddCarry(MachineState m, byte value)
-        {
-            var a = m.Cpu.Registers.A;
-            var sum = a + value + (m.Cpu.Registers.HasFlag(StatusFlagType.Carry)? 1 : 0);
-            var carry = sum > 0xFF;
-            var overflow = (~(a ^ value) & (a ^ sum) & 0x80) > 0;
-            m.Cpu.Registers.A = (byte)sum;
-            m.Cpu.Registers.SetFlag(StatusFlagType.Carry, carry);
-            m.Cpu.Registers.SetFlag(StatusFlagType.Overflow, overflow);
-        }
-
-        static void OpRollingLeftShiftMem(MachineState m, ushort target)
-        {
-            var prev_carry = m.Cpu.Registers.HasFlag(StatusFlagType.Carry);
-            var c_flag = (m[target] & 0b_1000_0000) > 0;
-            m[target] <<= 1;
-            if (prev_carry) m[target] |= 0b_0000_0001;
-            m.Cpu.Registers.UpdateFlags(m[target]);
-            m.Cpu.Registers.SetFlag(StatusFlagType.Carry, c_flag);
-        }
-
-        static void OpRollingRightShiftMem(MachineState m, ushort target)
-        {
-            var prev_carry = m.Cpu.Registers.HasFlag(StatusFlagType.Carry);
-            var c_flag = (m[target] & 0b_0000_0001) > 0;
-            m[target] >>= 1;
-            if (prev_carry) m[target] |= 0b_1000_0000;
-            m.Cpu.Registers.UpdateFlags(m[target]);
-            m.Cpu.Registers.SetFlag(StatusFlagType.Carry, c_flag);
-        }
-        // Todo; make sure all address setting functions are setting flags properly
-        static void OpIncMem(MachineState m, ushort target)
-        {
-            m[target]++;
-            m.Cpu.Registers.UpdateFlags(m[target]);
-        }
-
-        static void OpDecMem(MachineState m, ushort target)
-        {
-            m[target]--;
-            m.Cpu.Registers.UpdateFlags(m[target]);
-        }
-
-        static void OpBit(MachineState m, byte value)
-        {
-            m.Cpu.Registers.SetFlag(StatusFlagType.Zero, (m.Cpu.Registers.A & value) == 0);
-            m.Cpu.Registers.SetFlag(StatusFlagType.Negative, (value & 0b_1000_0000) > 0);
-            m.Cpu.Registers.SetFlag(StatusFlagType.Overflow, (value & 0b_0100_0000) > 0);
-        }
-        #endregion
-
-        static readonly CpuInstruction[] instructions_unordered = new CpuInstruction[] {
-
-            new() { Name = "JMP", OpCode = 0x4C, Bytes = 3, Process = new ProcessDelegate[] {
-                m => {
-                    m.Cpu.tmp_u = m.Cpu.Registers.PC;
-                    PCL(m, m[(ushort)(m.Cpu.tmp_u + 1)]);
-                },
-                m => {
-                    PCH(m, m[(ushort)(m.Cpu.tmp_u + 2)]);
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${m.Cpu.Registers.PC:X4}";
-                },
-            } },
-
-            new() { Name = "LDX", OpCode = 0xA2, Bytes = 2, Process = new ProcessDelegate[] {
-                m => {
-                    m.Cpu.Registers.X = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    m.Cpu.Registers.PC += 2;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"#${m.Cpu.Registers.X:X2}";
-                },
-            } },
-
-            new() { Name = "STX", OpCode = 0x86, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
-                    m[target] = m.Cpu.Registers.X;
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "JSR", OpCode = 0x20, Bytes = 3, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => {
-                    PUSH_ushort(m, (ushort)(m.Cpu.Registers.PC + 2));
-                    m.Cpu.Registers.PC = m.ReadUShort(m.Cpu.Registers.PC + 1);
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${m.Cpu.Registers.PC:X4}";
-                },
-            } },
-
-            new() { Name = "RTS", OpCode = 0x60, Bytes = 1, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => {
-                    ushort target = PULL(m);
-                    target |= (ushort)((ushort)PULL(m) << 8);
-                    m.Cpu.Registers.PC = target;
-                    m.Cpu.Registers.PC += 1;
-                },
-            } },
-
-            new() { Name = "NOP", OpCode = 0xEA, Bytes = 1, Process = new ProcessDelegate[] {
-                m => { m.Cpu.Registers.PC++; },
-            } },
-
-            new() { Name = "SEC", OpCode = 0x38, Bytes = 1, Process = new ProcessDelegate[] {
-                m => OpSetFlag(m, StatusFlagType.Carry),
-            } },
-
-            new() { Name = "BCS", OpCode = 0xB0, Bytes = 2, Process = new ProcessDelegate[] {
-                m => OpBranchOnFlagRelative(m, StatusFlagType.Carry),
-            } },
-
-            new() { Name = "CLC", OpCode = 0x18, Bytes = 1, Process = new ProcessDelegate[] {
-                m => OpClearFlag(m, StatusFlagType.Carry),
-            } },
-
-            new() { Name = "BCC", OpCode = 0x90, Bytes = 2, Process = new ProcessDelegate[] {
-                m => OpBranchOnClearFlagRelative(m, StatusFlagType.Carry),
-            } },
-
-            new() { Name = "LDA", OpCode = 0xA9, Bytes = 2, Process = new ProcessDelegate[] {
-                m => {
-                    m.Cpu.Registers.A = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    m.Cpu.Registers.PC += 2;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"#${m.Cpu.Registers.A:X2}";
-                },
-            } },
-
-            new() { Name = "BEQ", OpCode = 0xF0, Bytes = 2, Process = new ProcessDelegate[] {
-                m => OpBranchOnFlagRelative(m, StatusFlagType.Zero),
-            } },
-
-            new() { Name = "BNE", OpCode = 0xD0, Bytes = 2, Process = new ProcessDelegate[] {
-                m => OpBranchOnClearFlagRelative(m, StatusFlagType.Zero),
-            } },
-
-            new() { Name = "STA", OpCode = 0x85, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
-                    m[target] = m.Cpu.Registers.A;
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "BIT", OpCode = 0x24, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var z_p_address = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    var value = m[z_p_address];
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${z_p_address:X2} = {value:X2}";
-                    OpBit(m, value);
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "BVS", OpCode = 0x70, Bytes = 2, Process = new ProcessDelegate[] {
-                m => OpBranchOnFlagRelative(m, StatusFlagType.Overflow),
-            } },
-
-            new() { Name = "BVC", OpCode = 0x50, Bytes = 2, Process = new ProcessDelegate[] {
-                m => OpBranchOnClearFlagRelative(m, StatusFlagType.Overflow),
-            } },
-
-            new() { Name = "BPL", OpCode = 0x10, Bytes = 2, Process = new ProcessDelegate[] {
-                m => OpBranchOnClearFlagRelative(m, StatusFlagType.Negative),
-            } },
-
-            new() { Name = "SEI", OpCode = 0x78, Bytes = 1, Process = new ProcessDelegate[] {
-                m => OpSetFlag(m, StatusFlagType.InerruptDisable),
-            } },
-
-            new() { Name = "SED", OpCode = 0xF8, Bytes = 1, Process = new ProcessDelegate[] {
-                m => OpSetFlag(m, StatusFlagType.Decimal),
-            } },
-
-            new() { Name = "PHP", OpCode = 0x08, Bytes = 1, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var p = m.Cpu.Registers.P;
-                    p |= 0b_0010_0000;
-                    PUSH(m, p);
-                    m.Cpu.Registers.PC++;
-                },
-            } },
-
-            new() { Name = "PLA", OpCode = 0x68, Bytes = 1, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => {
-                    m.Cpu.Registers.A = PULL(m);
-                    m.Cpu.Registers.PC++;
-                },
-            } },
-
-            new() { Name = "AND", OpCode = 0x29, Bytes = 2, Process = new ProcessDelegate[] {
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    m.Cpu.Registers.A &= target;
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "CMP", OpCode = 0xC9, Bytes = 2, Process = new ProcessDelegate[] {
-                m => {
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"#${m[(ushort)(m.Cpu.Registers.PC + 1)]:X2}";
-                    OpCompare(m, m.Cpu.Registers.A, m[(ushort)(m.Cpu.Registers.PC + 1)]);
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "CLD", OpCode = 0xD8, Bytes = 1, Process = new ProcessDelegate[] {
-                m => OpClearFlag(m, StatusFlagType.Decimal),
-            } },
-
-            new() { Name = "PHA", OpCode = 0x48, Bytes = 1, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    PUSH(m, m.Cpu.Registers.A);
-                    m.Cpu.Registers.PC++;
-                },
-            } },
-
-            new() { Name = "PLP", OpCode = 0x28, Bytes = 1, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => {
-                    var b_flag = m.Cpu.Registers.HasFlag(StatusFlagType.BFlag);
-                    m.Cpu.Registers.P = PULL(m);
-                    m.Cpu.Registers.SetFlag(StatusFlagType.BFlag, b_flag);
-                    m.Cpu.Registers.PC++;
-                },
-            } },
-
-            new() { Name = "BMI", OpCode = 0x30, Bytes = 2, Process = new ProcessDelegate[] {
-                m => OpBranchOnFlagRelative(m, StatusFlagType.Negative),
-            } },
-
-            new() { Name = "ORA", OpCode = 0x09, Bytes = 2, Process = new ProcessDelegate[] {
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    m.Cpu.Registers.A |= target;
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "CLV", OpCode = 0xB8, Bytes = 1, Process = new ProcessDelegate[] {
-                m => OpClearFlag(m, StatusFlagType.Overflow),
-            } },
-
-            new() { Name = "EOR", OpCode = 0x49, Bytes = 2, Process = new ProcessDelegate[] {
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    m.Cpu.Registers.A ^= target;
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "ADC", OpCode = 0x69, Bytes = 2, Process = new ProcessDelegate[] {
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"#${target:X2}";
-                    OpAddCarry(m, target);
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "LDY", OpCode = 0xA0, Bytes = 2, Process = new ProcessDelegate[] {
-                m => {
-                    m.Cpu.Registers.Y = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    m.Cpu.Registers.PC += 2;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"#${m.Cpu.Registers.Y:X2}";
-                },
-            } },
-
-            new() { Name = "CPY", OpCode = 0xC0, Bytes = 2, Process = new ProcessDelegate[] {
-                m => {
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"#${m[(ushort)(m.Cpu.Registers.PC + 1)]:X2}";
-                    OpCompare(m, m.Cpu.Registers.Y, m[(ushort)(m.Cpu.Registers.PC + 1)]);
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "CPX", OpCode = 0xE0, Bytes = 2, Process = new ProcessDelegate[] {
-                m => {
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"#${m[(ushort)(m.Cpu.Registers.PC + 1)]:X2}";
-                    OpCompare(m, m.Cpu.Registers.X, m[(ushort)(m.Cpu.Registers.PC + 1)]);
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "SBC", OpCode = 0xE9, Bytes = 2, Process = new ProcessDelegate[] {
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"#${target:X2}";
-                    OpAddCarry(m, (byte)~target);
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "INY", OpCode = 0xC8, Bytes = 1, Process = new ProcessDelegate[] {
-                m => {
-                    m.Cpu.Registers.Y++;
-                    m.Cpu.Registers.PC += 1;
-                },
-            } },
-
-            new() { Name = "INX", OpCode = 0xE8, Bytes = 1, Process = new ProcessDelegate[] {
-                m => {
-                    m.Cpu.Registers.X++;
-                    m.Cpu.Registers.PC += 1;
-                },
-            } },
-
-            new() { Name = "DEY", OpCode = 0x88, Bytes = 1, Process = new ProcessDelegate[] {
-                m => {
-                    m.Cpu.Registers.Y--;
-                    m.Cpu.Registers.PC += 1;
-                },
-            } },
-
-            new() { Name = "DEX", OpCode = 0xCA, Bytes = 1, Process = new ProcessDelegate[] {
-                m => {
-                    m.Cpu.Registers.X--;
-                    m.Cpu.Registers.PC += 1;
-                },
-            } },
-
-            new() { Name = "TAY", OpCode = 0xA8, Bytes = 1, Process = new ProcessDelegate[] {
-                m => {
-                    m.Cpu.Registers.Y = m.Cpu.Registers.A;
-                    m.Cpu.Registers.PC += 1;
-                },
-            } },
-
-            new() { Name = "TAX", OpCode = 0xAA, Bytes = 1, Process = new ProcessDelegate[] {
-                m => {
-                    m.Cpu.Registers.X = m.Cpu.Registers.A;
-                    m.Cpu.Registers.PC += 1;
-                },
-            } },
-
-            new() { Name = "TYA", OpCode = 0x98, Bytes = 1, Process = new ProcessDelegate[] {
-                m => {
-                    m.Cpu.Registers.A = m.Cpu.Registers.Y;
-                    m.Cpu.Registers.PC += 1;
-                },
-            } },
-
-            new() { Name = "TXA", OpCode = 0x8A, Bytes = 1, Process = new ProcessDelegate[] {
-                m => {
-                    m.Cpu.Registers.A = m.Cpu.Registers.X;
-                    m.Cpu.Registers.PC += 1;
-                },
-            } },
-
-            new() { Name = "TSX", OpCode = 0xBA, Bytes = 1, Process = new ProcessDelegate[] {
-                m => {
-                    m.Cpu.Registers.X = m.Cpu.Registers.S;
-                    m.Cpu.Registers.PC += 1;
-                },
-            } },
-
-
-            new() { Name = "STX", OpCode = 0x8E, Bytes = 3, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => {
-                    var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
-                    m[target] = m.Cpu.Registers.X;
-                    m.Cpu.Registers.PC += 3;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m.Cpu.Registers.X:X2}";
-                },
-            } },
-
-            new() { Name = "TXS", OpCode = 0x9A, Bytes = 1, Process = new ProcessDelegate[] {
-                m => {
-                    m.Cpu.Registers.S = m.Cpu.Registers.X;
-                    m.Cpu.Registers.PC += 1;
-                },
-            } },
-
-            new() { Name = "LDX", OpCode = 0xAE, Bytes = 3, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => {
-                    var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
-                    m.Cpu.Registers.X = m[target];
-                    m.Cpu.Registers.PC += 3;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m.Cpu.Registers.X:X2}";
-                },
-            } },
-
-            new() { Name = "LDA", OpCode = 0xAD, Bytes = 3, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => {
-                    var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
-                    m.Cpu.Registers.A = m[target];
-                    m.Cpu.Registers.PC += 3;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m.Cpu.Registers.A:X2}";
-                },
-            } },
-
-            new() { Name = "DEC", OpCode = 0xCE, Bytes = 3, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => {
-                    var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
-                    m[target]--;
-                    m.Cpu.Registers.PC += 3;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m.Cpu.Registers.A:X2}";
-                },
-            } },
-
-            new() { Name = "RTI", OpCode = 0x40, Bytes = 1, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => {
-                    m.Cpu.Registers.P = PULL(m);
-                    m.Cpu.Registers.PC = PULL_ushort(m);
-                },
-            } },
-
-            new() { Name = "LSR", OpCode = 0x4A, Bytes = 1, Process = new ProcessDelegate[] {
-                m => {
-                    var c_flag = (m.Cpu.Registers.A & 0b_0000_0001) > 0;
-                    m.Cpu.Registers.A >>= 1;
-                    m.Cpu.Registers.SetFlag(StatusFlagType.Carry, c_flag);
-                    m.Cpu.Registers.PC += 1;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"A";
-                },
-            } },
-
-            new() { Name = "ASL", OpCode = 0x0A, Bytes = 1, Process = new ProcessDelegate[] {
-                m => {
-                    var c_flag = (m.Cpu.Registers.A & 0b_1000_0000) > 0;
-                    m.Cpu.Registers.A <<= 1;
-                    m.Cpu.Registers.SetFlag(StatusFlagType.Carry, c_flag);
-                    m.Cpu.Registers.PC += 1;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"A";
-                },
-            } },
-
-            new() { Name = "ROR", OpCode = 0x6A, Bytes = 1, Process = new ProcessDelegate[] {
-                m => {
-                    var prev_carry = m.Cpu.Registers.HasFlag(StatusFlagType.Carry);
-                    var c_flag = (m.Cpu.Registers.A & 0b_0000_0001) > 0;
-                    m.Cpu.Registers.A >>= 1;
-                    if (prev_carry) m.Cpu.Registers.A |= 0b_1000_0000;
-                    m.Cpu.Registers.SetFlag(StatusFlagType.Carry, c_flag);
-                    m.Cpu.Registers.PC += 1;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"A";
-                },
-            } },
-
-            new() { Name = "ROL", OpCode = 0x2A, Bytes = 1, Process = new ProcessDelegate[] {
-                m => {
-                    var prev_carry = m.Cpu.Registers.HasFlag(StatusFlagType.Carry);
-                    var c_flag = (m.Cpu.Registers.A & 0b_1000_0000) > 0;
-                    m.Cpu.Registers.A <<= 1;
-                    if (prev_carry) m.Cpu.Registers.A |= 0b_0000_0001;
-                    m.Cpu.Registers.SetFlag(StatusFlagType.Carry, c_flag);
-                    m.Cpu.Registers.PC += 1;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"A";
-                },
-            } },
-
-            new() { Name = "LDA", OpCode = 0xA5, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    m.Cpu.Registers.A = m[target];
-                    m.Cpu.Registers.PC += 2;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m.Cpu.Registers.A:X2}";
-                },
-            } },
-
-            new() { Name = "STA", OpCode = 0x8D, Bytes = 3, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => { },
-                m => {
-                    var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m[target]:X2}";
-                    m[target] = m.Cpu.Registers.A;
-                    m.Cpu.Registers.PC += 3;
-                },
-            } },
-
-            new() { Name = "LDA", OpCode = 0xA1, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => {
-                    var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    var target = GetIndexedZeroPageIndirectAddress(m, arg, m.Cpu.Registers.X);
-                    m.Cpu.Registers.A = m[target];
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "STA", OpCode = 0x81, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => {
-                    var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    var target = GetIndexedZeroPageIndirectAddress(m, arg, m.Cpu.Registers.X);
-                    m[target] = m.Cpu.Registers.A;
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "ORA", OpCode = 0x01, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => {
-                    var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    var target = GetIndexedZeroPageIndirectAddress(m, arg, m.Cpu.Registers.X);
-                    m.Cpu.Registers.A |= m[target];
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "AND", OpCode = 0x21, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => {
-                    var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    var target = GetIndexedZeroPageIndirectAddress(m, arg, m.Cpu.Registers.X);
-                    m.Cpu.Registers.A &= m[target];
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "EOR", OpCode = 0x41, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => {
-                    var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    var target = GetIndexedZeroPageIndirectAddress(m, arg, m.Cpu.Registers.X);
-                    m.Cpu.Registers.A ^= m[target];
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "ADC", OpCode = 0x61, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => {
-                    var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    var target = GetIndexedZeroPageIndirectAddress(m, arg, m.Cpu.Registers.X);
-                    OpAddCarry(m, m[target]);
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "CMP", OpCode = 0xC1, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => {
-                    var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    var target = GetIndexedZeroPageIndirectAddress(m, arg, m.Cpu.Registers.X);
-                    OpCompare(m, m.Cpu.Registers.A, m[target]);
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "SBC", OpCode = 0xE1, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => {
-                    var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    var target = GetIndexedZeroPageIndirectAddress(m, arg, m.Cpu.Registers.X);
-                    OpAddCarry(m, (byte)~m[target]);
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "LDY", OpCode = 0xA4, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    m.Cpu.Registers.Y = m[target];
-                    m.Cpu.Registers.PC += 2;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m.Cpu.Registers.Y:X2}";
-                },
-            } },
-
-            new() { Name = "STY", OpCode = 0x84, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    m[target] = m.Cpu.Registers.Y;
-                    m.Cpu.Registers.PC += 2;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m.Cpu.Registers.Y:X2}";
-                },
-            } },
-
-            new() { Name = "LDX", OpCode = 0xA6, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    m.Cpu.Registers.X = m[target];
-                    m.Cpu.Registers.PC += 2;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m.Cpu.Registers.X:X2}";
-                },
-            } },
-
-            new() { Name = "ORA", OpCode = 0x05, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    m.Cpu.Registers.A |= m[target];
-                    m.Cpu.Registers.PC += 2;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
-                },
-            } },
-
-            new() { Name = "AND", OpCode = 0x25, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    m.Cpu.Registers.A &= m[target];
-                    m.Cpu.Registers.PC += 2;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
-                },
-            } },
-
-            new() { Name = "EOR", OpCode = 0x45, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    m.Cpu.Registers.A ^= m[target];
-                    m.Cpu.Registers.PC += 2;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
-                },
-            } },
-
-            new() { Name = "ADC", OpCode = 0x65, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    OpAddCarry(m, (byte)m[target]);
-                    m.Cpu.Registers.PC += 2;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
-                },
-            } },
-
-            new() { Name = "CMP", OpCode = 0xC5, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    OpCompare(m, m.Cpu.Registers.A, m[target]);
-                    m.Cpu.Registers.PC += 2;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
-                },
-            } },
-
-            new() { Name = "SBC", OpCode = 0xE5, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
-                    OpAddCarry(m, (byte)~m[target]);
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "CPX", OpCode = 0xE4, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    OpCompare(m, m.Cpu.Registers.X, m[target]);
-                    m.Cpu.Registers.PC += 2;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
-                },
-            } },
-
-            new() { Name = "CPY", OpCode = 0xC4, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var target = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    OpCompare(m, m.Cpu.Registers.Y, m[target]);
-                    m.Cpu.Registers.PC += 2;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X2} = {m[target]:X2}";
-                },
-            } },
-
-            new() { Name = "LSR", OpCode = 0x46, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${arg:X2} = {m[arg]:X2}";
-
-                    var c_flag = (m[arg] & 0b_0000_0001) > 0;
-                    m[arg] >>= 1;
-                    m.Cpu.Registers.SetFlag(StatusFlagType.Carry, c_flag);
-
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "ASL", OpCode = 0x06, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => {
-                    var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${arg:X2} = {m[arg]:X2}";
-
-                    var c_flag = (m[arg] & 0b_1000_0000) > 0;
-                    m[arg] <<= 1;
-                    m.Cpu.Registers.SetFlag(StatusFlagType.Carry, c_flag);
-
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "ROR", OpCode = 0x66, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => {
-                    var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${arg:X2} = {m[arg]:X2}";
-
-                    OpRollingRightShiftMem(m, arg);
-
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "ROL", OpCode = 0x26, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => {
-                    var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${arg:X2} = {m[arg]:X2}";
-
-                    OpRollingLeftShiftMem(m, arg);
-
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "INC", OpCode = 0xE6, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => {
-                    var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${arg:X2} = {m[arg]:X2}";
-
-                    OpIncMem(m, arg);
-
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "DEC", OpCode = 0xC6, Bytes = 2, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => { },
-                m => { },
-                m => {
-                    var arg = m[(ushort)(m.Cpu.Registers.PC + 1)];
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${arg:X2} = {m[arg]:X2}";
-
-                    OpDecMem(m, arg);
-
-                    m.Cpu.Registers.PC += 2;
-                },
-            } },
-
-            new() { Name = "LDY", OpCode = 0xAC, Bytes = 3, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => {
-                    var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
-                    m.Cpu.Registers.Y = m[target];
-                    m.Cpu.Registers.PC += 3;
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m.Cpu.Registers.Y:X2}";
-                },
-            } },
-
-            new() { Name = "STY", OpCode = 0x8C, Bytes = 3, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => {
-                    var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m[target]:X2}";
-                    m[target] = m.Cpu.Registers.Y;
-                    m.Cpu.Registers.PC += 3;
-                },
-            } },
-
-            new() { Name = "BIT", OpCode = 0x2C, Bytes = 3, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => {
-                    var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m[target]:X2}";
-                    OpBit(m, m[target]);
-                    m.Cpu.Registers.PC += 3;
-                },
-            } },
-
-            new() { Name = "ORA", OpCode = 0x0D, Bytes = 3, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => {
-                    var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m[target]:X2}";
-                    m.Cpu.Registers.A |= m[target];
-                    m.Cpu.Registers.PC += 3;
-                },
-            } },
-
-            new() { Name = "AND", OpCode = 0x2D, Bytes = 3, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => {
-                    var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m[target]:X2}";
-                    m.Cpu.Registers.A &= m[target];
-                    m.Cpu.Registers.PC += 3;
-                },
-            } },
-
-            new() { Name = "EOR", OpCode = 0x4D, Bytes = 3, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => {
-                    var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m[target]:X2}";
-                    m.Cpu.Registers.A ^= m[target];
-                    m.Cpu.Registers.PC += 3;
-                },
-            } },
-
-            new() { Name = "ADC", OpCode = 0x6D, Bytes = 3, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => {
-                    var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m[target]:X2}";
-                    OpAddCarry(m, m[target]);
-                    m.Cpu.Registers.PC += 3;
-                },
-            } },
-
-            new() { Name = "CMP", OpCode = 0xCD, Bytes = 3, Process = new ProcessDelegate[] {
-                m => { },
-                m => { },
-                m => {
-                    var target = m.ReadUShort(m.Cpu.Registers.PC + 1);
-                    if (m.Settings.System.DebugMode) m.Cpu.log_message = $"${target:X4} = {m[target]:X2}";
-                    OpCompare(m, m.Cpu.Registers.A, m[target]);
-                    m.Cpu.Registers.PC += 3;
-                },
-            } },
-        };
-
-        public Cpu(MachineState machine)
-        {
-            this.machine = machine;
-            foreach (var i in instructions_unordered) {
-                if (instructions[i.OpCode] != null) throw new Exception($"Duplicate OpCodes: {instructions[i.OpCode].Name} and {i.Name}");
-                instructions[i.OpCode] = i;
-            }
-        }
-
-        public void SetPowerUpState()
-        {
-            Registers.PC = 0x34;
-            Registers.X = 0;
-            Registers.Y = 0;
-            Registers.A = 0;
-
-            // I just put InerruptDisable/0xFD here because these seem to be set in the nestest.log file by the time it gets here but I haven't found anything in documentation to say why
-            Registers.P = (byte)StatusFlagType._1 | (byte)StatusFlagType.InerruptDisable;
-            Registers.S = 0xFD;
-        }
-
-        public void Tick()
-        {
-            CycleCounter++;
+            var opcode = machine[Registers.PC];
+            CurrentInstruction = instructions[opcode];
             if (CurrentInstruction == null)
             {
-                var opcode = machine[Registers.PC];
-                CurrentInstruction = instructions[opcode];
-                if (CurrentInstruction == null)
-                {
-                    var op_x = opcode.ToString("X2");
-                    //PrintCpuGrid();
-                    throw new NotImplementedException($"Opcode {opcode:X2} not implemented. {instructions_unordered.Length}/151 opcodes are implemented!");
-                }
-                if (machine.Settings.System.DebugMode)
-                {
-                    log_pc = Registers.PC;
-                    log_d1 = CurrentInstruction.Bytes < 2 ? null : machine[(ushort)(Registers.PC + 1)];
-                    log_d2 = CurrentInstruction.Bytes < 3 ? null : machine[(ushort)(Registers.PC + 2)];
-                    log_cyc = CycleCounter;
-                    log_cpu = Registers.GetLog();
-                    log_inst_count++;
-                }
+                var op_x = opcode.ToString("X2");
+                //PrintCpuGrid();
+                throw new NotImplementedException($"Opcode {opcode:X2} not implemented. {instructions_unordered.Length}/151 opcodes are implemented!");
             }
-            else
+            if (machine.Settings.System.DebugMode)
             {
-                if (CurrentInstructionCycle < CurrentInstruction.Process.Length) CurrentInstruction.Process[CurrentInstructionCycle++](machine);
-                if (CurrentInstructionCycle == CurrentInstruction.Process.Length)
-                {
-                    if (add_cycles > 0)
-                    {
-                        add_cycles--;
-                        return;
-                    }
-                    if (machine.Settings.System.DebugMode) {
-                        machine.Logger.Log(new(CurrentInstruction, log_pc, log_d1, log_d2, log_cpu, log_cyc, log_message));
-                        log_message = null;
-                    }
-                    CurrentInstruction = null;
-                    CurrentInstructionCycle = 0;
-                }
+                log_pc = Registers.PC;
+                log_d1 = CurrentInstruction.Bytes < 2 ? null : machine[(ushort)(Registers.PC + 1)];
+                log_d2 = CurrentInstruction.Bytes < 3 ? null : machine[(ushort)(Registers.PC + 2)];
+                log_cyc = CycleCounter;
+                log_cpu = Registers.GetLog();
+                log_inst_count++;
             }
         }
-
-        void PrintCpuGrid()
+        else
         {
-            StringBuilder sb = new();
-
-            string block = "■";
-
-            for (int i = 0; i < 0xFF; i++)
+            if (CurrentInstructionCycle < CurrentInstruction.Process.Length) CurrentInstruction.Process[CurrentInstructionCycle++](machine);
+            if (CurrentInstructionCycle == CurrentInstruction.Process.Length)
             {
-                if (instructions[i] != null) sb.Append(block);
-                else sb.Append(' ');
-                if ((i % 16) == 15) sb.Append('\n');
-
+                if (add_cycles > 0)
+                {
+                    add_cycles--;
+                    return;
+                }
+                if (machine.Settings.System.DebugMode) {
+                    machine.Logger.Log(new(CurrentInstruction, log_pc, log_d1, log_d2, log_cpu, log_cyc, log_message));
+                    log_message = null;
+                }
+                CurrentInstruction = null;
+                CurrentInstructionCycle = 0;
             }
-
-            Debug.WriteLine(sb.ToString());
         }
+    }
+
+    void PrintCpuGrid()
+    {
+        StringBuilder sb = new();
+
+        string block = "■";
+
+        for (int i = 0; i < 0xFF; i++)
+        {
+            if (instructions[i] != null) sb.Append(block);
+            else sb.Append(' ');
+            if ((i % 16) == 15) sb.Append('\n');
+
+        }
+
+        Debug.WriteLine(sb.ToString());
     }
 }

--- a/MNES.Core/Machine/CPU/CpuInstruction.cs
+++ b/MNES.Core/Machine/CPU/CpuInstruction.cs
@@ -4,17 +4,16 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Mnes.Core.Machine.CPU
-{
-    public class CpuInstruction
-    {
-        /// <summary> Iterates through each clock cycle of a CPU instruction. </summary>
-        public delegate void ProcessDelegate(MachineState state);
+namespace Mnes.Core.Machine.CPU;
 
-        public string Name { get; init; }
-        public byte OpCode { get; init; }
-        public int Bytes { get; init; }
-        public bool Illegal { get; init; }
-        public ProcessDelegate[] Process { get; init; }
-    }
+public class CpuInstruction
+{
+    /// <summary> Iterates through each clock cycle of a CPU instruction. </summary>
+    public delegate void ProcessDelegate(MachineState state);
+
+    public string Name { get; init; }
+    public byte OpCode { get; init; }
+    public int Bytes { get; init; }
+    public bool Illegal { get; init; }
+    public ProcessDelegate[] Process { get; init; }
 }

--- a/MNES.Core/Machine/CpuRegisters.cs
+++ b/MNES.Core/Machine/CpuRegisters.cs
@@ -1,100 +1,99 @@
 ﻿using MNES.Core.Machine.Logging;
 
-namespace Mnes.Core.Machine
+namespace Mnes.Core.Machine;
+
+// https://www.nesdev.org/wiki/CPU_registers
+/// <summary> Represents all the registers of the CPU. </summary>
+public class CpuRegisters
 {
-    // https://www.nesdev.org/wiki/CPU_registers
-    /// <summary> Represents all the registers of the CPU. </summary>
-    public class CpuRegisters
+    public enum StatusFlagType
     {
-        public enum StatusFlagType
-        {
-            /// <summary> The C flag. </summary>
-            Carry =             0b_0000_0001,
-            /// <summary> The Z flag. </summary>
-            Zero =              0b_0000_0010,
-            /// <summary> The I flag. </summary>
-            InerruptDisable =   0b_0000_0100,
-            /// <summary> The D flag. </summary>
-            Decimal =           0b_0000_1000,
-            /// <summary> The B flag. </summary>
-            BFlag =             0b_0001_0000,
-            /// <summary> The 1 flag. </summary>
-            _1 =                0b_0010_0000,
-            /// <summary> The V flag. </summary>
-            Overflow =          0b_0100_0000,
-            /// <summary> The N flag. </summary>
-            Negative =          0b_1000_0000,
-        }
-
-        public enum RegisterType
-        {
-            A = 0,
-            X = 1,
-            Y = 2,
-            S = 3,
-            P = 4,
-        }
-
-        /// <summary> The 5 8-bit registers. </summary>
-        readonly byte[] registers = new byte[5];
-        /// <summary> The program counter. </summary>
-        public ushort PC;
-
-
-        public byte this[RegisterType index]
-        {
-            get => registers[(int)index];
-            set => registers[(int)index] = value;
-        }
-
-        /// <summary> The accumulator. </summary>
-        public byte A { get => registers[0]; set => SetRegisterAndFlags(RegisterType.A, value); }
-
-        /// <summary> The X register. </summary>
-        public byte X { get => registers[1]; set => SetRegisterAndFlags(RegisterType.X, value); }
-
-        /// <summary> The Y register. </summary>
-        public byte Y { get => registers[2]; set => SetRegisterAndFlags(RegisterType.Y, value); }
-
-        /// <summary> The stack pointer. </summary>
-        public byte S { get => registers[3]; set => registers[3] = value; }
-
-        /// <summary> The status register. </summary>
-        public byte P { get => registers[4]; set => registers[4] = (byte)(value | (byte)StatusFlagType._1); }
-
-        public byte GetRegister(RegisterType r) => registers[(int)r];
-
-        public void SetRegister(RegisterType r, byte value)
-        {
-            if ((int)r < (int)RegisterType.S) SetRegisterAndFlags(r, value);
-            else registers[(int)r] = value;
-        }
-
-        /// <summary> Set register value and handle status flag updating. </summary>
-        void SetRegisterAndFlags(RegisterType r, byte value)
-        {
-            registers[(int)r] = value;
-            SetFlag(StatusFlagType.Negative, (value & 0b_1000_0000) > 0);
-            SetFlag(StatusFlagType.Zero, value == 0);
-        }
-
-        /// <summary> Set relevant flags from value in memory. </summary>
-        /// <param name="value"></param>
-        public void UpdateFlags(byte value)
-        {
-            SetFlag(StatusFlagType.Negative, (value & 0b_1000_0000) > 0);
-            SetFlag(StatusFlagType.Zero, value == 0);
-        }
-
-        public bool HasFlag(StatusFlagType flag) => (P & (byte)flag) > 0;
-        public void SetFlag(StatusFlagType flag) => P |= (byte)flag;
-        public void SetFlag(StatusFlagType flag, bool value)
-        {
-            if (value) P |= (byte)flag;
-            else P &= (byte)~(byte)flag;
-        }
-        public void ClearFlag(StatusFlagType flag) => P &= (byte)~flag;
-
-        public CpuRegisterLog GetLog() => new(this);
+        /// <summary> The C flag. </summary>
+        Carry =             0b_0000_0001,
+        /// <summary> The Z flag. </summary>
+        Zero =              0b_0000_0010,
+        /// <summary> The I flag. </summary>
+        InerruptDisable =   0b_0000_0100,
+        /// <summary> The D flag. </summary>
+        Decimal =           0b_0000_1000,
+        /// <summary> The B flag. </summary>
+        BFlag =             0b_0001_0000,
+        /// <summary> The 1 flag. </summary>
+        _1 =                0b_0010_0000,
+        /// <summary> The V flag. </summary>
+        Overflow =          0b_0100_0000,
+        /// <summary> The N flag. </summary>
+        Negative =          0b_1000_0000,
     }
+
+    public enum RegisterType
+    {
+        A = 0,
+        X = 1,
+        Y = 2,
+        S = 3,
+        P = 4,
+    }
+
+    /// <summary> The 5 8-bit registers. </summary>
+    readonly byte[] registers = new byte[5];
+    /// <summary> The program counter. </summary>
+    public ushort PC;
+
+
+    public byte this[RegisterType index]
+    {
+        get => registers[(int)index];
+        set => registers[(int)index] = value;
+    }
+
+    /// <summary> The accumulator. </summary>
+    public byte A { get => registers[0]; set => SetRegisterAndFlags(RegisterType.A, value); }
+
+    /// <summary> The X register. </summary>
+    public byte X { get => registers[1]; set => SetRegisterAndFlags(RegisterType.X, value); }
+
+    /// <summary> The Y register. </summary>
+    public byte Y { get => registers[2]; set => SetRegisterAndFlags(RegisterType.Y, value); }
+
+    /// <summary> The stack pointer. </summary>
+    public byte S { get => registers[3]; set => registers[3] = value; }
+
+    /// <summary> The status register. </summary>
+    public byte P { get => registers[4]; set => registers[4] = (byte)(value | (byte)StatusFlagType._1); }
+
+    public byte GetRegister(RegisterType r) => registers[(int)r];
+
+    public void SetRegister(RegisterType r, byte value)
+    {
+        if ((int)r < (int)RegisterType.S) SetRegisterAndFlags(r, value);
+        else registers[(int)r] = value;
+    }
+
+    /// <summary> Set register value and handle status flag updating. </summary>
+    void SetRegisterAndFlags(RegisterType r, byte value)
+    {
+        registers[(int)r] = value;
+        SetFlag(StatusFlagType.Negative, (value & 0b_1000_0000) > 0);
+        SetFlag(StatusFlagType.Zero, value == 0);
+    }
+
+    /// <summary> Set relevant flags from value in memory. </summary>
+    /// <param name="value"></param>
+    public void UpdateFlags(byte value)
+    {
+        SetFlag(StatusFlagType.Negative, (value & 0b_1000_0000) > 0);
+        SetFlag(StatusFlagType.Zero, value == 0);
+    }
+
+    public bool HasFlag(StatusFlagType flag) => (P & (byte)flag) > 0;
+    public void SetFlag(StatusFlagType flag) => P |= (byte)flag;
+    public void SetFlag(StatusFlagType flag, bool value)
+    {
+        if (value) P |= (byte)flag;
+        else P &= (byte)~(byte)flag;
+    }
+    public void ClearFlag(StatusFlagType flag) => P &= (byte)~flag;
+
+    public CpuRegisterLog GetLog() => new(this);
 }

--- a/MNES.Core/Machine/INesHeader.cs
+++ b/MNES.Core/Machine/INesHeader.cs
@@ -5,61 +5,60 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Mnes.Core.Machine
+namespace Mnes.Core.Machine;
+
+// https://www.nesdev.org/wiki/INES
+public class INesHeader
 {
-    // https://www.nesdev.org/wiki/INES
-    public class INesHeader
+    static readonly byte[] ines_text = new byte[] { 0x4E, 0x45, 0x53, 0x1A };
+
+    public readonly int PrgRomSize;
+    public readonly int ChrRomSize;
+    /// <summary>
+    /// Nametable arrangement: 0: vertical arrangement ("horizontal mirrored") (CIRAM A10 = PPU A11) 1: horizontal arrangement ("vertically mirrored") (CIRAM A10 = PPU A10)
+    /// </summary>
+    public readonly bool NameTableArrangment;
+    /// <summary>
+    /// Cartridge contains battery-backed PRG RAM ($6000-7FFF) or other persistent memory
+    /// </summary>
+    public readonly bool HasBatteryBackedPrgRam;
+    /// <summary>
+    /// 512-byte trainer at $7000-$71FF (stored before PRG data)
+    /// </summary>
+    public readonly bool HasTrainer;
+    public readonly bool AlternativeNametableLayout;
+    public readonly byte MapperNumber;
+    public readonly bool VsUnisystem;
+    public readonly bool PlayChoice10;
+    public readonly bool Nes2_0;
+
+    public readonly int PrgRamSize;
+
+    public readonly NesTimer.RegionType TvSystem;
+    public readonly bool PrgRam_6000_7FFF_Present;
+    public readonly bool HasBusConflicts;
+
+    public INesHeader(byte[] nes_file)
     {
-        static readonly byte[] ines_text = new byte[] { 0x4E, 0x45, 0x53, 0x1A };
-
-        public readonly int PrgRomSize;
-        public readonly int ChrRomSize;
-        /// <summary>
-        /// Nametable arrangement: 0: vertical arrangement ("horizontal mirrored") (CIRAM A10 = PPU A11) 1: horizontal arrangement ("vertically mirrored") (CIRAM A10 = PPU A10)
-        /// </summary>
-        public readonly bool NameTableArrangment;
-        /// <summary>
-        /// Cartridge contains battery-backed PRG RAM ($6000-7FFF) or other persistent memory
-        /// </summary>
-        public readonly bool HasBatteryBackedPrgRam;
-        /// <summary>
-        /// 512-byte trainer at $7000-$71FF (stored before PRG data)
-        /// </summary>
-        public readonly bool HasTrainer;
-        public readonly bool AlternativeNametableLayout;
-        public readonly byte MapperNumber;
-        public readonly bool VsUnisystem;
-        public readonly bool PlayChoice10;
-        public readonly bool Nes2_0;
-
-        public readonly int PrgRamSize;
-
-        public readonly NesTimer.RegionType TvSystem;
-        public readonly bool PrgRam_6000_7FFF_Present;
-        public readonly bool HasBusConflicts;
-
-        public INesHeader(byte[] nes_file)
-        {
-            // 0-3	Constant $4E $45 $53 $1A (ASCII "NES" followed by MS-DOS end-of-file)
-            if (!nes_file[..4].SequenceEqual(ines_text)) throw new Exception("ROM invalid, INES header not found.");
-            // 4	Size of PRG ROM in 16 KB units
-            PrgRomSize = nes_file[4] * 16000;
-            // 5	Size of CHR ROM in 8 KB units (value 0 means the board uses CHR RAM)
-            ChrRomSize = nes_file[5] * 8000;
-            // 6	Flags 6 – Mapper, mirroring, battery, trainer
-            NameTableArrangment = (nes_file[6] & 0b0000_0001) > 1;
-            HasBatteryBackedPrgRam = (nes_file[6] & 0b0000_0010) > 1;
-            HasTrainer = (nes_file[6] & 0b0000_0100) > 1;
-            MapperNumber = (byte)(nes_file[6] >> 4);
-            // 7	Flags 7 – Mapper, VS/Playchoice, NES 2.0
-            VsUnisystem = (nes_file[7] & 0b0000_0001) > 1;
-            PlayChoice10 = (nes_file[7] & 0b0000_0010) > 1;
-            Nes2_0 = ((nes_file[7] & 0b0000_0100) == 0) && ((nes_file[7] & 0b0000_1000) > 1);
-            // 8	Flags 8 – PRG-RAM size (rarely used extension)
-            PrgRamSize = nes_file[6] * 8000;
-            // 9	Flags 9 – TV system (rarely used extension)
-            // 10	Flags 10 – TV system, PRG-RAM presence (unofficial, rarely used extension)
-            // 11-15	Unused padding (should be filled with zero, but some rippers put their name across bytes 7-15)
-        }
+        // 0-3	Constant $4E $45 $53 $1A (ASCII "NES" followed by MS-DOS end-of-file)
+        if (!nes_file[..4].SequenceEqual(ines_text)) throw new Exception("ROM invalid, INES header not found.");
+        // 4	Size of PRG ROM in 16 KB units
+        PrgRomSize = nes_file[4] * 16000;
+        // 5	Size of CHR ROM in 8 KB units (value 0 means the board uses CHR RAM)
+        ChrRomSize = nes_file[5] * 8000;
+        // 6	Flags 6 – Mapper, mirroring, battery, trainer
+        NameTableArrangment = (nes_file[6] & 0b0000_0001) > 1;
+        HasBatteryBackedPrgRam = (nes_file[6] & 0b0000_0010) > 1;
+        HasTrainer = (nes_file[6] & 0b0000_0100) > 1;
+        MapperNumber = (byte)(nes_file[6] >> 4);
+        // 7	Flags 7 – Mapper, VS/Playchoice, NES 2.0
+        VsUnisystem = (nes_file[7] & 0b0000_0001) > 1;
+        PlayChoice10 = (nes_file[7] & 0b0000_0010) > 1;
+        Nes2_0 = ((nes_file[7] & 0b0000_0100) == 0) && ((nes_file[7] & 0b0000_1000) > 1);
+        // 8	Flags 8 – PRG-RAM size (rarely used extension)
+        PrgRamSize = nes_file[6] * 8000;
+        // 9	Flags 9 – TV system (rarely used extension)
+        // 10	Flags 10 – TV system, PRG-RAM presence (unofficial, rarely used extension)
+        // 11-15	Unused padding (should be filled with zero, but some rippers put their name across bytes 7-15)
     }
 }

--- a/MNES.Core/Machine/Input/ControllerState.cs
+++ b/MNES.Core/Machine/Input/ControllerState.cs
@@ -1,12 +1,11 @@
-﻿namespace Mnes.Core.Machine.Input
+﻿namespace Mnes.Core.Machine.Input;
+
+public class ControllerState
 {
-    public class ControllerState
-    {
-        public bool Up { get; set; }
-        public bool Down { get; set; }
-        public bool Left { get; set; }
-        public bool Right { get; set; }
-        public bool A { get; set; }
-        public bool B { get; set; }
-    }
+    public bool Up { get; set; }
+    public bool Down { get; set; }
+    public bool Left { get; set; }
+    public bool Right { get; set; }
+    public bool A { get; set; }
+    public bool B { get; set; }
 }

--- a/MNES.Core/Machine/Input/HotkeyState.cs
+++ b/MNES.Core/Machine/Input/HotkeyState.cs
@@ -4,10 +4,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Mnes.Core.Machine.Input
+namespace Mnes.Core.Machine.Input;
+
+public class HotkeyState
 {
-    public class HotkeyState
-    {
-        public bool FastForward { get; set; }
-    }
+    public bool FastForward { get; set; }
 }

--- a/MNES.Core/Machine/Input/InputState.cs
+++ b/MNES.Core/Machine/Input/InputState.cs
@@ -4,12 +4,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Mnes.Core.Machine.Input
+namespace Mnes.Core.Machine.Input;
+
+public class InputState
 {
-    public class InputState
-    {
-        public ControllerState C1 { get; } = new();
-        public ControllerState C2 { get; } = new();
-        public HotkeyState Hotkeys { get; } = new();
-    }
+    public ControllerState C1 { get; } = new();
+    public ControllerState C2 { get; } = new();
+    public HotkeyState Hotkeys { get; } = new();
 }

--- a/MNES.Core/Machine/Logging/CpuRegisterLog.cs
+++ b/MNES.Core/Machine/Logging/CpuRegisterLog.cs
@@ -5,39 +5,38 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace MNES.Core.Machine.Logging
+namespace MNES.Core.Machine.Logging;
+
+public readonly struct CpuRegisterLog
 {
-    public readonly struct CpuRegisterLog
+    /// <summary> The accumulator. </summary>
+    public readonly byte A;
+
+    /// <summary> The X register. </summary>
+    public readonly byte X;
+
+    /// <summary> The Y register. </summary>
+    public readonly byte Y;
+
+    /// <summary> The program counter. </summary>
+    public readonly ushort PC;
+
+    /// <summary> The stack pointer. </summary>
+    public readonly byte S;
+
+    /// <summary> The status register. </summary>
+    public readonly byte P;
+
+    public override string ToString() =>
+        $"A:{A:X2} X:{X:X2} Y:{Y:X2} P:{P:X2} S:{S:X2}";
+
+    public CpuRegisterLog(CpuRegisters r)
     {
-        /// <summary> The accumulator. </summary>
-        public readonly byte A;
-
-        /// <summary> The X register. </summary>
-        public readonly byte X;
-
-        /// <summary> The Y register. </summary>
-        public readonly byte Y;
-
-        /// <summary> The program counter. </summary>
-        public readonly ushort PC;
-
-        /// <summary> The stack pointer. </summary>
-        public readonly byte S;
-
-        /// <summary> The status register. </summary>
-        public readonly byte P;
-
-        public override string ToString() =>
-            $"A:{A:X2} X:{X:X2} Y:{Y:X2} P:{P:X2} S:{S:X2}";
-
-        public CpuRegisterLog(CpuRegisters r)
-        {
-            A = r.A; 
-            X = r.X;
-            Y = r.Y; 
-            PC = r.PC;
-            S = r.S;
-            P = r.P;
-        }
+        A = r.A;
+        X = r.X;
+        Y = r.Y;
+        PC = r.PC;
+        S = r.S;
+        P = r.P;
     }
 }

--- a/MNES.Core/Machine/Logging/InstructionLog.cs
+++ b/MNES.Core/Machine/Logging/InstructionLog.cs
@@ -6,33 +6,32 @@ using System.Reflection.Emit;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace MNES.Core.Machine.Logging
+namespace MNES.Core.Machine.Logging;
+
+public readonly struct InstructionLog
 {
-    public readonly struct InstructionLog
+    public readonly CpuInstruction Instruction;
+    public readonly ushort Address;
+    public readonly byte? D1;
+    public readonly byte? D2;
+    public readonly CpuRegisterLog CpuRegisters;
+    public readonly long ClockCycle;
+    public readonly string Message;
+
+    public InstructionLog(CpuInstruction instruction, ushort address, byte? d1, byte? d2, CpuRegisterLog log, long clock_cycle, string message)
     {
-        public readonly CpuInstruction Instruction;
-        public readonly ushort Address;
-        public readonly byte? D1;
-        public readonly byte? D2;
-        public readonly CpuRegisterLog CpuRegisters;
-        public readonly long ClockCycle;
-        public readonly string Message;
-
-        public InstructionLog(CpuInstruction instruction, ushort address, byte? d1, byte? d2, CpuRegisterLog log, long clock_cycle, string message)
-        {
-            Instruction = instruction;
-            Address = address;
-            D1 = d1;
-            D2 = d2;
-            CpuRegisters = log;
-            ClockCycle = clock_cycle;
-            Message = message;
-        }
-
-        public override string ToString() =>
-            $"{Address:X4}  " +
-            $"{Instruction.OpCode:X2} {D1?.ToString("X2") ?? ""} {D2?.ToString("X2") ?? ""}".PadRight(10) +
-            $"{Instruction.Name} {Message ?? ""}".PadRight(34) +
-            $"{CpuRegisters} CYC:{ClockCycle}";
+        Instruction = instruction;
+        Address = address;
+        D1 = d1;
+        D2 = d2;
+        CpuRegisters = log;
+        ClockCycle = clock_cycle;
+        Message = message;
     }
+
+    public override string ToString() =>
+        $"{Address:X4}  " +
+        $"{Instruction.OpCode:X2} {D1?.ToString("X2") ?? ""} {D2?.ToString("X2") ?? ""}".PadRight(10) +
+        $"{Instruction.Name} {Message ?? ""}".PadRight(34) +
+        $"{CpuRegisters} CYC:{ClockCycle}";
 }

--- a/MNES.Core/Machine/Logging/MachineLogger.cs
+++ b/MNES.Core/Machine/Logging/MachineLogger.cs
@@ -6,23 +6,22 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace MNES.Core.Machine.Logging
+namespace MNES.Core.Machine.Logging;
+
+public class MachineLogger
 {
-    public class MachineLogger
+    MachineState machine;
+
+    public List<InstructionLog> CpuLog { get; init; } = new();
+
+    public MachineLogger(MachineState machine)
     {
-        MachineState machine;
+        this.machine = machine;
+    }
 
-        public List<InstructionLog> CpuLog { get; init; } = new();
-
-        public MachineLogger(MachineState machine)
-        {
-            this.machine = machine;
-        }
-
-        public void Log(InstructionLog log)
-        {
-            CpuLog.Add(log);
-            Debug.WriteLine(CpuLog.Count.ToString().PadLeft(4) + " " + log);
-        }
+    public void Log(InstructionLog log)
+    {
+        CpuLog.Add(log);
+        Debug.WriteLine(CpuLog.Count.ToString().PadLeft(4) + " " + log);
     }
 }

--- a/MNES.Core/Machine/MachineState.cs
+++ b/MNES.Core/Machine/MachineState.cs
@@ -5,90 +5,89 @@ using Mnes.Core.Machine.Mappers.Implementation;
 using Mnes.Core.Saves.Configuration;
 using MNES.Core.Machine.Logging;
 
-namespace Mnes.Core.Machine
+namespace Mnes.Core.Machine;
+
+public class MachineState
 {
-    public class MachineState
+    readonly INesHeader header;
+    readonly Mapper mapper;
+    readonly NesTimer timer;
+    readonly InputState input;
+    byte last_read_value = 0; // returns in case of open bus reads
+
+    public readonly byte[] Ram = new byte[0x0800];
+    public readonly byte[] Rom;
+    public readonly Ppu Ppu = new();
+    public readonly Apu Apu = new();
+    public readonly Cpu Cpu;
+    public readonly MachineLogger Logger;
+    public readonly ConfigSettings Settings;
+
+    public MachineState(string rom_path, ConfigSettings settings, InputState input)
     {
-        readonly INesHeader header;
-        readonly Mapper mapper;
-        readonly NesTimer timer;
-        readonly InputState input;
-        byte last_read_value = 0; // returns in case of open bus reads
+        this.Settings = settings;
+        this.input = input;
+        var nes_bytes = File.ReadAllBytes(rom_path);
+        header = new INesHeader(nes_bytes);
+        Rom = new byte[nes_bytes.Length - 16];
+        nes_bytes[16..].CopyTo(Rom, 0);
+        mapper = Mapper.GetMapper(header, this);
+        if (mapper == null) throw new NotImplementedException($"Mapper {header.MapperNumber} is not implemented.");
+        Cpu = new(this);
+        timer = new(settings.System.Region, settings.System.DebugMode ? DebugTick : Cpu.Tick);
+        Logger = new(this);
+    }
 
-        public readonly byte[] Ram = new byte[0x0800];
-        public readonly byte[] Rom;
-        public readonly Ppu Ppu = new();
-        public readonly Apu Apu = new();
-        public readonly Cpu Cpu;
-        public readonly MachineLogger Logger;
-        public readonly ConfigSettings Settings;
+    public async Task Run()
+    {
+        SetPowerUpState();
+        //Cpu.Registers.PC = (ushort)(this[0xFFFC] + (this[0xFFFD] << 8));
+        var r = ReadUShort(0xFFFC);
 
-        public MachineState(string rom_path, ConfigSettings settings, InputState input)
-        {
-            this.Settings = settings;
-            this.input = input;
-            var nes_bytes = File.ReadAllBytes(rom_path);
-            header = new INesHeader(nes_bytes);
-            Rom = new byte[nes_bytes.Length - 16];
-            nes_bytes[16..].CopyTo(Rom, 0);
-            mapper = Mapper.GetMapper(header, this);
-            if (mapper == null) throw new NotImplementedException($"Mapper {header.MapperNumber} is not implemented.");
-            Cpu = new(this);
-            timer = new(settings.System.Region, settings.System.DebugMode ? DebugTick : Cpu.Tick);
-            Logger = new(this);
+        Cpu.Registers.PC = 0xC000;
+        timer.Start();
+        await timer.RunningThread;
+    }
+
+    void DebugTick()
+    {
+        Cpu.Tick();
+    }
+
+    void SetPowerUpState()
+    {
+        Cpu.SetPowerUpState();
+        Ppu.SetPowerUpState();
+        Apu.SetPowerUpState();
+        for (int i = 0; i < Ram.Length; i++) Ram[i] = 0xFF;
+    }
+
+    public ushort ReadUShort(int index) => ReadUShort((ushort)index);
+    public ushort ReadUShort(ushort index)
+    {
+        var b_l = this[index];
+        ushort b_h = this[(ushort)(index + 1)];
+        b_h <<= 8;
+        b_h |= b_l;
+        return b_h;
+    }
+
+    /// <summary> If reads null, then open bus read. Don't write null. </summary>
+    public byte this[ushort index] {
+        get {
+            last_read_value =
+                index < 0x2000 ? Ram[index % 0x0800] :
+                index < 0x4000 ? Ppu.Registers[index % 8] :
+                index < 0x4020 ? Apu.Registers[index - 0x4000] :
+                mapper[index] ?? last_read_value;
+            return last_read_value;
         }
-
-        public async Task Run()
+        set
         {
-            SetPowerUpState();
-            //Cpu.Registers.PC = (ushort)(this[0xFFFC] + (this[0xFFFD] << 8));
-            var r = ReadUShort(0xFFFC);
-
-            Cpu.Registers.PC = 0xC000;
-            timer.Start();
-            await timer.RunningThread;
-        }
-
-        void DebugTick()
-        {
-            Cpu.Tick();
-        }
-
-        void SetPowerUpState()
-        {
-            Cpu.SetPowerUpState();
-            Ppu.SetPowerUpState();
-            Apu.SetPowerUpState();
-            for (int i = 0; i < Ram.Length; i++) Ram[i] = 0xFF;
-        }
-
-        public ushort ReadUShort(int index) => ReadUShort((ushort)index);
-        public ushort ReadUShort(ushort index)
-        {
-            var b_l = this[index];
-            ushort b_h = this[(ushort)(index + 1)];
-            b_h <<= 8;
-            b_h |= b_l;
-            return b_h;
-        }
-
-        /// <summary> If reads null, then open bus read. Don't write null. </summary>
-        public byte this[ushort index] {
-            get {
-                last_read_value =
-                    index < 0x2000 ? Ram[index % 0x0800] :
-                    index < 0x4000 ? Ppu.Registers[index % 8] :
-                    index < 0x4020 ? Apu.Registers[index - 0x4000] :
-                    mapper[index] ?? last_read_value;
-                return last_read_value;
-            }
-            set
-            {
-                if (index < 0x2000) Ram[index % 0x0800] = value;
-                else if (index < 0x4000) Ppu.Registers[index % 8] = value;
-                else if (index < 0x4020) Apu.Registers[index - 0x4000] = value;
-                else mapper[index] = value;
-            }
+            if (index < 0x2000) Ram[index % 0x0800] = value;
+            else if (index < 0x4000) Ppu.Registers[index % 8] = value;
+            else if (index < 0x4020) Apu.Registers[index - 0x4000] = value;
+            else mapper[index] = value;
         }
     }
 }

--- a/MNES.Core/Machine/Mappers/Implementation/M000.cs
+++ b/MNES.Core/Machine/Mappers/Implementation/M000.cs
@@ -4,35 +4,34 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Mnes.Core.Machine.Mappers.Implementation
+namespace Mnes.Core.Machine.Mappers.Implementation;
+
+internal class M000 : Mapper
 {
-    internal class M000 : Mapper
-    {
-        byte[] prg_ram;
-        bool mirror_rom_8000_BFFF;
+    byte[] prg_ram;
+    bool mirror_rom_8000_BFFF;
 
-        public override int MapperNumber => 0;
+    public override int MapperNumber => 0;
 
-        // Just ignoring this for now
-        protected override MapperBank[] Banks { get; } = new MapperBank[] { 
-            //new(MapperBank.AccessorType.CPU, MapperBank.BankType.PRG_RAM, new Range(0x6000, 0x8000), new(0x0000, 0x2000))
-        };
+    // Just ignoring this for now
+    protected override MapperBank[] Banks { get; } = new MapperBank[] {
+        //new(MapperBank.AccessorType.CPU, MapperBank.BankType.PRG_RAM, new Range(0x6000, 0x8000), new(0x0000, 0x2000))
+    };
 
-        public override byte? this[ushort i] { 
-            get {
-                if (i >= 0x6000 && i < 0x8000) return prg_ram?[i - 0x6000];
-                if (i >= 0x8000 && i < 0xC000) return Machine.Rom[i - 0x8000];
-                if (i >= 0xC000) return mirror_rom_8000_BFFF ? Machine.Rom[(i - 0xC000) % 16000] : Machine.Rom[i - 0xC000];
-                return null;
-            }
-            set {
-                if (prg_ram != null && i - 0x6000 < prg_ram.Length) prg_ram[i - 0x6000] = value.Value;
-            }
+    public override byte? this[ushort i] {
+        get {
+            if (i >= 0x6000 && i < 0x8000) return prg_ram?[i - 0x6000];
+            if (i >= 0x8000 && i < 0xC000) return Machine.Rom[i - 0x8000];
+            if (i >= 0xC000) return mirror_rom_8000_BFFF ? Machine.Rom[(i - 0xC000) % 16000] : Machine.Rom[i - 0xC000];
+            return null;
         }
-
-        public M000(INesHeader header, MachineState machine) : base(header, machine) { 
-            if (header.PrgRam_6000_7FFF_Present) prg_ram = new byte[header.PrgRamSize];
-            mirror_rom_8000_BFFF = header.PrgRomSize == 16000;
+        set {
+            if (prg_ram != null && i - 0x6000 < prg_ram.Length) prg_ram[i - 0x6000] = value.Value;
         }
+    }
+
+    public M000(INesHeader header, MachineState machine) : base(header, machine) {
+        if (header.PrgRam_6000_7FFF_Present) prg_ram = new byte[header.PrgRamSize];
+        mirror_rom_8000_BFFF = header.PrgRomSize == 16000;
     }
 }

--- a/MNES.Core/Machine/Mappers/Mapper.cs
+++ b/MNES.Core/Machine/Mappers/Mapper.cs
@@ -6,26 +6,25 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Mnes.Core.Machine.Mappers
+namespace Mnes.Core.Machine.Mappers;
+
+// https://www.nesdev.org/wiki/Mapper
+public abstract class Mapper
 {
-    // https://www.nesdev.org/wiki/Mapper
-    public abstract class Mapper
+    protected readonly MachineState Machine;
+    public abstract int MapperNumber { get; }
+
+    protected abstract MapperBank[] Banks { get; }
+
+    public Mapper(INesHeader header, MachineState machine)
     {
-        protected readonly MachineState Machine;
-        public abstract int MapperNumber { get; }
-
-        protected abstract MapperBank[] Banks { get; }
-
-        public Mapper(INesHeader header, MachineState machine)
-        {
-            Machine = machine;
-        }
-
-        /// <summary> If reads null, then open bus read. Don't write null. </summary>
-        public abstract byte? this[ushort index] { get; set; }
-
-        public static Mapper GetMapper(INesHeader header, MachineState machine) =>
-            header.MapperNumber == 0 ? new M000(header, machine) :
-            null;
+        Machine = machine;
     }
+
+    /// <summary> If reads null, then open bus read. Don't write null. </summary>
+    public abstract byte? this[ushort index] { get; set; }
+
+    public static Mapper GetMapper(INesHeader header, MachineState machine) =>
+        header.MapperNumber == 0 ? new M000(header, machine) :
+        null;
 }

--- a/MNES.Core/Machine/Mappers/MapperBank.cs
+++ b/MNES.Core/Machine/Mappers/MapperBank.cs
@@ -4,35 +4,34 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Mnes.Core.Machine.Mappers
+namespace Mnes.Core.Machine.Mappers;
+
+public class MapperBank
 {
-    public class MapperBank
+    public enum AccessorType
     {
-        public enum AccessorType
-        {
-            CPU,
-            PPU,
-        }
+        CPU,
+        PPU,
+    }
 
-        public enum BankType
-        {
-            PRG_RAM,
-            ROM,
-            CHR,
-        }
+    public enum BankType
+    {
+        PRG_RAM,
+        ROM,
+        CHR,
+    }
 
-        public AccessorType Accessor { get; init; }
-        public BankType Type { get; init; }
-        public Range AccessRange { get; init; }
-        public Range DestinationRange { get; init; }
-        public ushort MemorySize { get; init; }
+    public AccessorType Accessor { get; init; }
+    public BankType Type { get; init; }
+    public Range AccessRange { get; init; }
+    public Range DestinationRange { get; init; }
+    public ushort MemorySize { get; init; }
 
-        public MapperBank(AccessorType accessor, BankType type, Range access_range, Range destination_range)
-        {
-            Accessor = accessor;
-            Type = type;
-            AccessRange = access_range;
-            DestinationRange = destination_range;
-        }
+    public MapperBank(AccessorType accessor, BankType type, Range access_range, Range destination_range)
+    {
+        Accessor = accessor;
+        Type = type;
+        AccessRange = access_range;
+        DestinationRange = destination_range;
     }
 }

--- a/MNES.Core/Machine/NesTimer.cs
+++ b/MNES.Core/Machine/NesTimer.cs
@@ -2,113 +2,112 @@
 using Newtonsoft.Json.Converters;
 using System.Diagnostics;
 
-namespace Mnes.Core.Machine
+namespace Mnes.Core.Machine;
+
+public class NesTimer
 {
-    public class NesTimer
+    public const int PAL_TIMING_HZ = 1660000;
+    public const int NTSC_TIMING_HZ = 1790000;
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum RegionType : int
     {
-        public const int PAL_TIMING_HZ = 1660000;
-        public const int NTSC_TIMING_HZ = 1790000;
+        PAL = PAL_TIMING_HZ,
+        NTSC = NTSC_TIMING_HZ,
+        DUAL_COMPATIBLE,
+    }
 
-        [JsonConverter(typeof(StringEnumConverter))]
-        public enum RegionType : int
+    public Task RunningThread { get; private set; }
+    Action tick_callback;
+    int _hertz;
+    RegionType _region_backing = RegionType.NTSC;
+    bool _is_running = false;
+    bool _is_paused = false;
+    bool _is_stopping = false;
+    public long TotalTickCount { get; private set; }
+
+    RegionType Region {
+        get => _region_backing;
+        set {
+            if (value == RegionType.NTSC) _hertz = NTSC_TIMING_HZ;
+            else if (value == RegionType.PAL) _hertz = PAL_TIMING_HZ;
+        }
+    }
+
+    public NesTimer(RegionType region, Action tick)
+    {
+        Region = region;
+        tick_callback = tick;
+    }
+
+    /// <summary> Starts or unpauses the timer. </summary>
+    public void Start() {
+        if (_is_running && _is_paused) {
+            _is_paused = false;
+            return;
+        }
+        if (_is_running) throw new Exception($"{nameof(NesTimer)} is already running.");
+        RunningThread = Task.Run(Run);
+    }
+
+    void Run()
+    {
+        _is_running = true;
+
+        var stop_watch = new Stopwatch();
+
+        int ticks_per_ms = _hertz / 1000;
+
+        void reset_state()
         {
-            PAL = PAL_TIMING_HZ,
-            NTSC = NTSC_TIMING_HZ,
-            DUAL_COMPATIBLE,
+            TotalTickCount = 0;
+            _is_running = false;
+            _is_paused = false;
+            _is_stopping = false;
         }
 
-        public Task RunningThread { get; private set; }
-        Action tick_callback;
-        int _hertz;
-        RegionType _region_backing = RegionType.NTSC;
-        bool _is_running = false;
-        bool _is_paused = false;
-        bool _is_stopping = false;
-        public long TotalTickCount { get; private set; }
-
-        RegionType Region {
-            get => _region_backing; 
-            set {
-                if (value == RegionType.NTSC) _hertz = NTSC_TIMING_HZ;
-                else if (value == RegionType.PAL) _hertz = PAL_TIMING_HZ;
-            }
-        }
-
-        public NesTimer(RegionType region, Action tick)
+        stop_watch.Start();
+        while (_is_running)
         {
-            Region = region;
-            tick_callback = tick;
-        }
-
-        /// <summary> Starts or unpauses the timer. </summary>
-        public void Start() {
-            if (_is_running && _is_paused) {
-                _is_paused = false;
+            Thread.Sleep(1);
+            var elapsed = stop_watch.Elapsed;
+            if (_is_stopping) {
+                reset_state();
                 return;
             }
-            if (_is_running) throw new Exception($"{nameof(NesTimer)} is already running.");
-            RunningThread = Task.Run(Run);
-        }
-
-        void Run()
-        {
-            _is_running = true;
-
-            var stop_watch = new Stopwatch();
-
-            int ticks_per_ms = _hertz / 1000;
-
-            void reset_state()
-            {
-                TotalTickCount = 0;
-                _is_running = false;
-                _is_paused = false;
-                _is_stopping = false; 
+            if (_is_paused){
+                do {
+                    Thread.Sleep(1);
+                    if (_is_stopping) {
+                        reset_state();
+                        return;
+                    }
+                } while (_is_paused);
             }
+            stop_watch.Restart();
 
-            stop_watch.Start();
-            while (_is_running)
-            {
-                Thread.Sleep(1);
-                var elapsed = stop_watch.Elapsed;
-                if (_is_stopping) {
-                    reset_state();
-                    return;
-                }
-                if (_is_paused){
-                    do {
-                        Thread.Sleep(1);
-                        if (_is_stopping) {
-                            reset_state();
-                            return;
-                        }
-                    } while (_is_paused);
-                }
-                stop_watch.Restart();
-
-                var tick_count = (int)(ticks_per_ms * elapsed.TotalMilliseconds);
-                for (int i = 0; i < tick_count; i++) tick_callback();
-                TotalTickCount += tick_count;
-            }
+            var tick_count = (int)(ticks_per_ms * elapsed.TotalMilliseconds);
+            for (int i = 0; i < tick_count; i++) tick_callback();
+            TotalTickCount += tick_count;
         }
+    }
 
-        public void Pause() {
-            if (_is_paused) throw new Exception($"{nameof(NesTimer)} is already paused.");
-            if (!_is_running) throw new Exception($"Cannot pause {nameof(NesTimer)} when it's not running.");
-            _is_paused = true;
-        }
+    public void Pause() {
+        if (_is_paused) throw new Exception($"{nameof(NesTimer)} is already paused.");
+        if (!_is_running) throw new Exception($"Cannot pause {nameof(NesTimer)} when it's not running.");
+        _is_paused = true;
+    }
 
-        public void Reset() {
-            if (!_is_running) throw new Exception($"Cannot reset {nameof(NesTimer)} when it's not running.");
-            _is_stopping = true;
-            RunningThread.Wait();
-            Start();
-        }
+    public void Reset() {
+        if (!_is_running) throw new Exception($"Cannot reset {nameof(NesTimer)} when it's not running.");
+        _is_stopping = true;
+        RunningThread.Wait();
+        Start();
+    }
 
-        public void Stop() {
-            if (!_is_running) throw new Exception($"Cannot stop {nameof(NesTimer)} when it's not running.");
-            _is_stopping = true;
-            RunningThread.Wait();
-        }
+    public void Stop() {
+        if (!_is_running) throw new Exception($"Cannot stop {nameof(NesTimer)} when it's not running.");
+        _is_stopping = true;
+        RunningThread.Wait();
     }
 }

--- a/MNES.Core/Machine/PPU.cs
+++ b/MNES.Core/Machine/PPU.cs
@@ -4,43 +4,42 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Mnes.Core.Machine
+namespace Mnes.Core.Machine;
+
+// https://www.nesdev.org/wiki/PPU_registers
+public class Ppu
 {
-    // https://www.nesdev.org/wiki/PPU_registers
-    public class Ppu
+    public byte[] Registers = new byte[8];
+    public byte OAMDMA;
+
+    // VPHB SINN
+    // NMI enable (V), PPU master/slave (P), sprite height (H), background tile select (B), sprite tile select (S), increment mode (I), nametable select (NN)
+    byte PpuCtrl => Registers[0];
+    // BGRs bMmG
+    // color emphasis (BGR), sprite enable (s), background enable (b), sprite left column enable (M), background left column enable (m), greyscale (G)
+    byte PpuMask => Registers[1];
+    // VSO- ----
+    // 	vblank (V), sprite 0 hit (S), sprite overflow (O); read resets write pair for $2005/$2006
+    byte PpuStatus => Registers[2];
+    // aaaa aaaa
+    // OAM read/write address
+    byte OamAddr => Registers[3];
+    // dddd dddd
+    // OAM data read/write
+    byte OamData => Registers[4];
+    // xxxx xxxx
+    // fine scroll position (two writes: X scroll, Y scroll)
+    byte PpuScroll => Registers[5];
+    // aaaa aaaa
+    // PPU read/write address (two writes: most significant byte, least significant byte)
+    byte PpuAddr => Registers[6];
+    // dddd dddd
+    // PPU data read/write
+    byte PpuData => Registers[7];
+
+    public void SetPowerUpState()
     {
-        public byte[] Registers = new byte[8];
-        public byte OAMDMA;
-
-        // VPHB SINN
-        // NMI enable (V), PPU master/slave (P), sprite height (H), background tile select (B), sprite tile select (S), increment mode (I), nametable select (NN)
-        byte PpuCtrl => Registers[0];
-        // BGRs bMmG
-        // color emphasis (BGR), sprite enable (s), background enable (b), sprite left column enable (M), background left column enable (m), greyscale (G)
-        byte PpuMask => Registers[1];
-        // VSO- ----
-        // 	vblank (V), sprite 0 hit (S), sprite overflow (O); read resets write pair for $2005/$2006
-        byte PpuStatus => Registers[2];
-        // aaaa aaaa
-        // OAM read/write address
-        byte OamAddr => Registers[3];
-        // dddd dddd
-        // OAM data read/write
-        byte OamData => Registers[4];
-        // xxxx xxxx
-        // fine scroll position (two writes: X scroll, Y scroll)
-        byte PpuScroll => Registers[5];
-        // aaaa aaaa
-        // PPU read/write address (two writes: most significant byte, least significant byte)
-        byte PpuAddr => Registers[6];
-        // dddd dddd
-        // PPU data read/write
-        byte PpuData => Registers[7];
-
-        public void SetPowerUpState()
-        {
-            Array.Clear(Registers);
-            OAMDMA = 0;
-        }
+        Array.Clear(Registers);
+        OAMDMA = 0;
     }
 }

--- a/MNES.Core/Machine/StatusFlags.cs
+++ b/MNES.Core/Machine/StatusFlags.cs
@@ -4,19 +4,18 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Mnes.Core.Machine
+namespace Mnes.Core.Machine;
+
+public static class StatusFlags
 {
-    public static class StatusFlags
-    {
-        public const byte CARRY = 0b00000001;
-        public const byte ZERO = 0b00000010;
-        public const byte INTERRUPT_DISABLE = 0b00000100;
-        public const byte DECIMAL = 0b00001000;
+    public const byte CARRY = 0b00000001;
+    public const byte ZERO = 0b00000010;
+    public const byte INTERRUPT_DISABLE = 0b00000100;
+    public const byte DECIMAL = 0b00001000;
 
-        public const byte B = 0b00010000;
-        public const byte UNUSED = 0b00100000;
-        public const byte OVERFLOW = 0b01000000;
-        public const byte NEGATIVE = 0b10000000;
+    public const byte B = 0b00010000;
+    public const byte UNUSED = 0b00100000;
+    public const byte OVERFLOW = 0b01000000;
+    public const byte NEGATIVE = 0b10000000;
 
-    }
 }

--- a/MNES.Core/Saves/Configuration/Config.cs
+++ b/MNES.Core/Saves/Configuration/Config.cs
@@ -2,68 +2,67 @@
 using IniParser.Model;
 using Newtonsoft.Json;
 
-namespace Mnes.Core.Saves.Configuration
+namespace Mnes.Core.Saves.Configuration;
+
+public static class Config
 {
-    public static class Config
+    const string DEFAULT_SAVE_FOLDER = "%AppData%/MNES";
+
+    const string DEFAULT_INI_TEXT =
+        $"; The location of the save folder. If it doesn't exist, it will be created. You can set this to a local path to make this portable.\n" +
+        $"SaveFolder = {DEFAULT_SAVE_FOLDER}";
+
+    const string LOCAL_CONFIG_FILE = "local_config.ini";
+
+    const string CONFIG_FILE = "config.json";
+
+    public static bool Initialized => Settings != null;
+
+    static string _save_folder;
+
+    public static ConfigSettings Settings { get; private set; }
+
+    public static void InitializeFromDisk()
     {
-        const string DEFAULT_SAVE_FOLDER = "%AppData%/MNES";
+        ConfigSettings settings = null;
 
-        const string DEFAULT_INI_TEXT =
-            $"; The location of the save folder. If it doesn't exist, it will be created. You can set this to a local path to make this portable.\n" +
-            $"SaveFolder = {DEFAULT_SAVE_FOLDER}";
+        if (Initialized) throw new Exception("Config already initialized.");
 
-        const string LOCAL_CONFIG_FILE = "local_config.ini";
-
-        const string CONFIG_FILE = "config.json";
-
-        public static bool Initialized => Settings != null;
-
-        static string _save_folder;
-
-        public static ConfigSettings Settings { get; private set; }
-
-        public static void InitializeFromDisk()
+        if (!File.Exists(LOCAL_CONFIG_FILE))
         {
-            ConfigSettings settings = null;
-
-            if (Initialized) throw new Exception("Config already initialized.");
-
-            if (!File.Exists(LOCAL_CONFIG_FILE))
-            {
-                File.WriteAllText(LOCAL_CONFIG_FILE, DEFAULT_INI_TEXT);
-            }
-
-            var parser = new FileIniDataParser();
-            IniData data = parser.ReadFile(LOCAL_CONFIG_FILE);
-
-            data.TryGetKey("SaveFolder", out _save_folder);
-            if (string.IsNullOrEmpty(_save_folder)) _save_folder = DEFAULT_SAVE_FOLDER;
-            _save_folder = Environment.ExpandEnvironmentVariables(_save_folder);
-            if (!Directory.Exists(_save_folder)) Directory.CreateDirectory(_save_folder);
-
-            if (!File.Exists(Path.Combine(_save_folder, CONFIG_FILE)))
-            {
-                settings = new();
-                File.WriteAllText(
-                    Path.Combine(_save_folder, CONFIG_FILE),
-                    JsonConvert.SerializeObject(settings));
-            }
-            else settings = JsonConvert.DeserializeObject<ConfigSettings>(Path.Combine(_save_folder, CONFIG_FILE));
-
-            Settings = settings;
+            File.WriteAllText(LOCAL_CONFIG_FILE, DEFAULT_INI_TEXT);
         }
 
-        public static void Save()
-        {
-            if (!Initialized) throw new Exception($"Cannot save config before {nameof(InitializeFromDisk)} has been called.");
-            File.WriteAllText(Path.Combine(_save_folder, CONFIG_FILE), JsonConvert.SerializeObject(Settings));
-        }
+        var parser = new FileIniDataParser();
+        IniData data = parser.ReadFile(LOCAL_CONFIG_FILE);
 
-        /// <summary> Resets the settings to default and saves. </summary>
-        public static void Reset()
+        data.TryGetKey("SaveFolder", out _save_folder);
+        if (string.IsNullOrEmpty(_save_folder)) _save_folder = DEFAULT_SAVE_FOLDER;
+        _save_folder = Environment.ExpandEnvironmentVariables(_save_folder);
+        if (!Directory.Exists(_save_folder)) Directory.CreateDirectory(_save_folder);
+
+        if (!File.Exists(Path.Combine(_save_folder, CONFIG_FILE)))
         {
-            Settings = new();
-            Save();
+            settings = new();
+            File.WriteAllText(
+                Path.Combine(_save_folder, CONFIG_FILE),
+                JsonConvert.SerializeObject(settings));
         }
+        else settings = JsonConvert.DeserializeObject<ConfigSettings>(Path.Combine(_save_folder, CONFIG_FILE));
+
+        Settings = settings;
+    }
+
+    public static void Save()
+    {
+        if (!Initialized) throw new Exception($"Cannot save config before {nameof(InitializeFromDisk)} has been called.");
+        File.WriteAllText(Path.Combine(_save_folder, CONFIG_FILE), JsonConvert.SerializeObject(Settings));
+    }
+
+    /// <summary> Resets the settings to default and saves. </summary>
+    public static void Reset()
+    {
+        Settings = new();
+        Save();
     }
 }

--- a/MNES.Core/Saves/Configuration/ConfigSettings.cs
+++ b/MNES.Core/Saves/Configuration/ConfigSettings.cs
@@ -4,10 +4,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Mnes.Core.Saves.Configuration
+namespace Mnes.Core.Saves.Configuration;
+
+public class ConfigSettings
 {
-    public class ConfigSettings
-    {
-        public SystemConfig System { get; set; } = new();
-    }
+    public SystemConfig System { get; set; } = new();
 }

--- a/MNES.Core/Saves/Configuration/SystemConfig.cs
+++ b/MNES.Core/Saves/Configuration/SystemConfig.cs
@@ -5,12 +5,11 @@ using System.Text;
 using System.Threading.Tasks;
 using static Mnes.Core.Machine.NesTimer;
 
-namespace Mnes.Core.Saves.Configuration
-{
-    public class SystemConfig
-    {
-        public RegionType Region { get; set; } = RegionType.NTSC;
+namespace Mnes.Core.Saves.Configuration;
 
-        public bool DebugMode { get; set; }
-    }
+public class SystemConfig
+{
+    public RegionType Region { get; set; } = RegionType.NTSC;
+
+    public bool DebugMode { get; set; }
 }

--- a/MNES.Tests/Files/ConfigTests.cs
+++ b/MNES.Tests/Files/ConfigTests.cs
@@ -5,15 +5,14 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Mnes.Tests.Files
+namespace Mnes.Tests.Files;
+
+[TestClass]
+public class ConfigTests
 {
-    [TestClass]
-    public class ConfigTests
+    [TestMethod]
+    public void TestInitialization()
     {
-        [TestMethod]
-        public void TestInitialization()
-        {
-            Config.InitializeFromDisk();
-        }
+        Config.InitializeFromDisk();
     }
 }

--- a/MNES.Tests/Files/INesTests.cs
+++ b/MNES.Tests/Files/INesTests.cs
@@ -6,18 +6,17 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Mnes.Tests.Files
-{
-    [TestClass]
-    public class INesTests
-    {
-        [TestMethod]
-        public void TestHeader()
-        {
-            var rom_file = "Resources/Test Roms/other/nestest.nes";
+namespace Mnes.Tests.Files;
 
-            var nes_bytes = File.ReadAllBytes(rom_file);
-            INesHeader header = new(nes_bytes);
-        }
+[TestClass]
+public class INesTests
+{
+    [TestMethod]
+    public void TestHeader()
+    {
+        var rom_file = "Resources/Test Roms/other/nestest.nes";
+
+        var nes_bytes = File.ReadAllBytes(rom_file);
+        INesHeader header = new(nes_bytes);
     }
 }

--- a/MNES.Tests/Machine/MachineTests.cs
+++ b/MNES.Tests/Machine/MachineTests.cs
@@ -7,21 +7,20 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Mnes.Tests.Machine
-{
-    [TestClass]
-    public class MachineTests
-    {
-        string rom_file = "Resources/Test Roms/other/nestest.nes";
+namespace Mnes.Tests.Machine;
 
-        [TestMethod]
-        public async Task TestRun()
-        {
-            var input = new InputState();
-            var settings = new ConfigSettings();
-            settings.System.DebugMode = true;
-            var machine = new MachineState(rom_file, settings, input);
-            await machine.Run();
-        }
+[TestClass]
+public class MachineTests
+{
+    string rom_file = "Resources/Test Roms/other/nestest.nes";
+
+    [TestMethod]
+    public async Task TestRun()
+    {
+        var input = new InputState();
+        var settings = new ConfigSettings();
+        settings.System.DebugMode = true;
+        var machine = new MachineState(rom_file, settings, input);
+        await machine.Run();
     }
 }

--- a/MNES.Tests/Machine/TimerTests.cs
+++ b/MNES.Tests/Machine/TimerTests.cs
@@ -6,41 +6,40 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Mnes.Tests.Machine
+namespace Mnes.Tests.Machine;
+
+[TestClass]
+public class TimerTests
 {
-    [TestClass]
-    public class TimerTests
+    [TestMethod]
+    public void TestTimer()
     {
-        [TestMethod]
-        public void TestTimer()
-        {
-            ulong tick_count = 0;
-            ulong seconds_count = 0;
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
+        ulong tick_count = 0;
+        ulong seconds_count = 0;
+        var stopwatch = new Stopwatch();
+        stopwatch.Start();
 
-            void tick() {
-                if (tick_count++ % NesTimer.NTSC_TIMING_HZ == 0)
-                {
-                    Debug.WriteLine($"{nameof(NesTimer)} seconds elapsed: {seconds_count++}");
-                    Debug.WriteLine($"{nameof(Stopwatch)} seconds elapsed: {stopwatch.Elapsed.TotalSeconds}");
-                }
+        void tick() {
+            if (tick_count++ % NesTimer.NTSC_TIMING_HZ == 0)
+            {
+                Debug.WriteLine($"{nameof(NesTimer)} seconds elapsed: {seconds_count++}");
+                Debug.WriteLine($"{nameof(Stopwatch)} seconds elapsed: {stopwatch.Elapsed.TotalSeconds}");
             }
-
-            var nes_timer = new NesTimer(NesTimer.RegionType.NTSC, tick);
-            nes_timer.Start();
-            Thread.Sleep(TimeSpan.FromSeconds(10));
-            Debug.WriteLine("Pause for 2 seconds...");
-            nes_timer.Pause();
-            Thread.Sleep(TimeSpan.FromSeconds(2));
-            Debug.WriteLine("Start.");
-            nes_timer.Start();
-            Thread.Sleep(TimeSpan.FromSeconds(10));
-            Debug.WriteLine("Reset.");
-            nes_timer.Reset();
-            Thread.Sleep(TimeSpan.FromSeconds(5));
-            Debug.WriteLine("Done.");
-
         }
+
+        var nes_timer = new NesTimer(NesTimer.RegionType.NTSC, tick);
+        nes_timer.Start();
+        Thread.Sleep(TimeSpan.FromSeconds(10));
+        Debug.WriteLine("Pause for 2 seconds...");
+        nes_timer.Pause();
+        Thread.Sleep(TimeSpan.FromSeconds(2));
+        Debug.WriteLine("Start.");
+        nes_timer.Start();
+        Thread.Sleep(TimeSpan.FromSeconds(10));
+        Debug.WriteLine("Reset.");
+        nes_timer.Reset();
+        Thread.Sleep(TimeSpan.FromSeconds(5));
+        Debug.WriteLine("Done.");
+
     }
 }

--- a/MNES.Ui.MonoGame/Game1.cs
+++ b/MNES.Ui.MonoGame/Game1.cs
@@ -2,35 +2,34 @@
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 
-namespace Mnes
+namespace Mnes;
+
+public class Game1 : Game
 {
-    public class Game1 : Game
-    {
-        public string StartupRom;
+    public string StartupRom;
 
-        private GraphicsDeviceManager _graphics;
-        private SpriteBatch _spriteBatch;
+    private GraphicsDeviceManager _graphics;
+    private SpriteBatch _spriteBatch;
 
-        public Game1() {
-            _graphics = new GraphicsDeviceManager(this);
-            Content.RootDirectory = "Content";
-            IsMouseVisible = true;
-        }
+    public Game1() {
+        _graphics = new GraphicsDeviceManager(this);
+        Content.RootDirectory = "Content";
+        IsMouseVisible = true;
+    }
 
-        protected override void Initialize() {
-            base.Initialize();
-        }
+    protected override void Initialize() {
+        base.Initialize();
+    }
 
-        protected override void LoadContent() { _spriteBatch = new SpriteBatch(GraphicsDevice); }
+    protected override void LoadContent() { _spriteBatch = new SpriteBatch(GraphicsDevice); }
 
-        protected override void Update(GameTime gameTime) {
-            if (GamePad.GetState(PlayerIndex.One).Buttons.Back == ButtonState.Pressed || Keyboard.GetState().IsKeyDown(Keys.Escape)) Exit();
-            base.Update(gameTime);
-        }
+    protected override void Update(GameTime gameTime) {
+        if (GamePad.GetState(PlayerIndex.One).Buttons.Back == ButtonState.Pressed || Keyboard.GetState().IsKeyDown(Keys.Escape)) Exit();
+        base.Update(gameTime);
+    }
 
-        protected override void Draw(GameTime gameTime) {
-            GraphicsDevice.Clear(Color.CornflowerBlue);
-            base.Draw(gameTime);
-        }
+    protected override void Draw(GameTime gameTime) {
+        GraphicsDevice.Clear(Color.CornflowerBlue);
+        base.Draw(gameTime);
     }
 }


### PR DESCRIPTION
I've changed (almost) nothing but converting to file-scoped namespaces.

This results in a lot of whitespace only changes (-1 indent for most of file). Viewing whitespace changes can be toggled off which can make it simpler to look at the changes. With `git diff` it is the `-w` option. With `git gui` you can specify this flag in Edit -> Options. On github there is supposed to be a "view whitespace" or "toggle whitespace" checkbox somewhere that does the same thing. I don't see it myself yet though.

The only other changes I think would be that trailing-whitespace was removed in at least one place.